### PR TITLE
types: fix encoding of large numeric node ids

### DIFF
--- a/types/src/node_id.rs
+++ b/types/src/node_id.rs
@@ -66,7 +66,7 @@ impl BinaryEncoder<NodeId> for NodeId {
                 } else if self.namespace <= 255 && *value <= 65535 {
                     4
                 } else {
-                    11
+                    7
                 }
             }
             Identifier::String(ref value) => {
@@ -100,7 +100,7 @@ impl BinaryEncoder<NodeId> for NodeId {
                     // full node id
                     size += write_u8(stream, 0x2)?;
                     size += write_u16(stream, self.namespace)?;
-                    size += write_u64(stream, *value as u64)?;
+                    size += write_u32(stream, *value as u32)?;
                 }
             }
             Identifier::String(ref value) => {
@@ -138,7 +138,7 @@ impl BinaryEncoder<NodeId> for NodeId {
             }
             0x2 => {
                 let namespace = read_u16(stream)?;
-                let value = read_u64(stream)?;
+                let value = read_u32(stream)? as u64;
                 NodeId::new(namespace, value)
             }
             0x3 => {
@@ -407,7 +407,7 @@ impl BinaryEncoder<ExpandedNodeId> for ExpandedNodeId {
                     // full node id
                     size += write_u8(stream, data_encoding | 0x2)?;
                     size += write_u16(stream, self.node_id.namespace)?;
-                    size += write_u64(stream, *value as u64)?;
+                    size += write_u32(stream, *value as u32)?;
                 }
             }
             Identifier::String(ref value) => {
@@ -452,7 +452,7 @@ impl BinaryEncoder<ExpandedNodeId> for ExpandedNodeId {
             }
             0x2 => {
                 let namespace = read_u16(stream)?;
-                let value = read_u64(stream)?;
+                let value = read_u32(stream)? as u64;
                 NodeId::new(namespace, value)
             }
             0x3 => {

--- a/types/src/tests/encoding.rs
+++ b/types/src/tests/encoding.rs
@@ -167,6 +167,28 @@ fn node_id_4byte_numeric() {
 }
 
 #[test]
+fn node_id_large_namespace() {
+    let node_id = NodeId::new(0x100, 1u64);
+    assert!(node_id.is_numeric());
+
+    let expected_bytes = [0x2, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0];
+    serialize_and_compare(node_id.clone(), &expected_bytes);
+
+    serialize_test(node_id);
+}
+
+#[test]
+fn node_id_large_id() {
+let node_id = NodeId::new(1, 0xdeadbeefu64);
+    assert!(node_id.is_numeric());
+
+    let expected_bytes = [0x2, 0x1, 0x0, 0xef, 0xbe, 0xad, 0xde];
+    serialize_and_compare(node_id.clone(), &expected_bytes);
+
+    serialize_test(node_id);
+}
+
+#[test]
 fn node_id_string_5229() {
     // Sample from OPCUA Part 6 - 5.2.2.9
     let node_id = NodeId::new_string(1, "Hot水");


### PR DESCRIPTION
Currently, NodeIds of the "Numeric" type are encoded as a UInt16
NamespaceIndex and a UInt64 identifier. However, according to the spec
(Table 6 of Part 6), a UInt32 should be used for the identifier.

Fix the en-/decoder accordingly and add a test.

From my understanding of the standard, one could also argue to reduce the integer in the `Identifier` enum to an `UInt32`, but I'm not sure if this is actually correct.