### PR TITLE
Request the maximum possible session timeout when creating a session.

### DIFF
--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -528,7 +528,7 @@ impl Session {
             session_name,
             client_nonce,
             client_certificate,
-            requested_session_timeout: 0f64,
+            requested_session_timeout: std::f64::MAX,
             max_response_message_size: 0,
         };
 


### PR DESCRIPTION
The OPC UA server always revises the session timeout, but previously adjusted it to its configured minimum timeout.
Now the timeout is adjusted to the server's maximum session timeout.
As long as no logic is in place that takes revised_session_timeout into consideration and sends periodic keepalives, this is a simple fix to combat many cases of silently dropped sessions.