### PR TITLE
types: Add missing AttributeId values

### DIFF
--- a/server/src/services/attribute.rs
+++ b/server/src/services/attribute.rs
@@ -425,6 +425,11 @@ impl AttributeService {
                 AttributeId::Historizing => write_mask.contains(WriteMask::HISTORIZING),
                 AttributeId::Executable => write_mask.contains(WriteMask::EXECUTABLE),
                 AttributeId::UserExecutable => write_mask.contains(WriteMask::USER_EXECUTABLE),
+                AttributeId::DataTypeDefinition => write_mask.contains(WriteMask::DATA_TYPE_DEFINITION),
+                AttributeId::RolePermissions => write_mask.contains(WriteMask::ROLE_PERMISSIONS),
+                AttributeId::AccessRestrictions => write_mask.contains(WriteMask::ACCESS_RESTRICTIONS),
+                AttributeId::AccessLevelEx => write_mask.contains(WriteMask::ACCESS_LEVEL_EX),
+                AttributeId::UserRolePermissions => false // Reserved
             }
         } else {
             false

--- a/types/src/attribute.rs
+++ b/types/src/attribute.rs
@@ -26,6 +26,11 @@ pub enum AttributeId {
     Historizing = 20,
     Executable = 21,
     UserExecutable = 22,
+    DataTypeDefinition = 23,
+    RolePermissions = 24,
+    UserRolePermissions = 25,
+    AccessRestrictions = 26,
+    AccessLevelEx = 27,
 }
 
 impl AttributeId {
@@ -53,6 +58,11 @@ impl AttributeId {
             20 => AttributeId::Historizing,
             21 => AttributeId::Executable,
             22 => AttributeId::UserExecutable,
+            23 => AttributeId::DataTypeDefinition,
+            24 => AttributeId::RolePermissions,
+            25 => AttributeId::UserRolePermissions,
+            26 => AttributeId::AccessRestrictions,
+            27 => AttributeId::AccessLevelEx,
             _ => {
                 debug!("Invalid attribute id {}", attribute_id);
                 return Err(());

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -93,6 +93,8 @@ bitflags! {
 }
 
 // Write mask bits (similar but different to AttributesMask)
+//
+// See Part 3, Table 43
 bitflags! {
     pub struct WriteMask: u32 {
         /// Indicates if the AccessLevel Attribute is writable.
@@ -141,6 +143,16 @@ bitflags! {
         /// since this is handled by the AccessLevel and UserAccessLevel Attributes for the Variable.
         /// For Variables this bit shall be set to 0.
         const VALUE_FOR_VARIABLE_TYPE = 1 << 21;
+        /// Indicates if the DataTypeDefinition Attribute is writable.
+        const DATA_TYPE_DEFINITION = 1 << 22;
+        /// Indicates if the RolePermissions Attribute is writable.
+        const ROLE_PERMISSIONS = 1 << 23;
+        /// Indicates if the AccessRestrictions Attribute is writable
+        const ACCESS_RESTRICTIONS = 1 << 24;
+        /// Indicates if the AccessLevelEx Attribute is writable
+        const ACCESS_LEVEL_EX = 1 << 25;
+
+        // Bits 26-31. Reserved for future use. Shall always be zero.
     }
 }
 


### PR DESCRIPTION
OPC-UA spec Part 6, table A.1 gives a list of identifiers assigned to
attributes, where five attribute IDs were missing.

These were discovered with UaExpert that appears to explicitly request
some of these.