### PR TITLE
server/comms/tcp_transport: Set session settings to u16::MAX

### DIFF
--- a/server/src/comms/tcp_transport.rs
+++ b/server/src/comms/tcp_transport.rs
@@ -48,9 +48,9 @@ use crate::{
 };
 
 // TODO these need to go, and use session settings
-const RECEIVE_BUFFER_SIZE: usize = 1024 * 64;
-const SEND_BUFFER_SIZE: usize = 1024 * 64;
-const MAX_MESSAGE_SIZE: usize = 1024 * 64;
+const RECEIVE_BUFFER_SIZE: usize = std::u16::MAX as usize;
+const SEND_BUFFER_SIZE: usize = std::u16::MAX as usize;
+const MAX_MESSAGE_SIZE: usize = std::u16::MAX as usize;
 
 macro_rules! connection_finished_test {
     ( $id: expr, $connection:expr ) => {


### PR DESCRIPTION
The .NET UA standard client, NetCoreConsoleClient [1] fails to connect
to the sample simple-server, because it decodes a send_buffer_size and
receive_buffer_size that's one higher than it can handle internally.

My working theory is that the client is constrained to buffers of 16
bits, but I'm completely sure of this yet.

Setting the buffer sizes to u16::MAX allows the client to connect and
successfully read the address space of simple-server.

[1] https://github.com/OPCFoundation/UA-.NETStandard/tree/master/SampleApplications/Samples/NetCoreConsoleClient