### PR TITLE
Make it possible to use custom named .pem certs

### DIFF
--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -114,6 +114,22 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets a custom client certificate path. The path is required to be provided as a partial
+    /// path relative to the PKI directory. If set, this path will be used to read the client
+    /// certificate from disk. The certificate can be in either the .der or .pem format.
+    pub fn certificate_path<T>(mut self, certificate_path: T) -> Self where T: Into<PathBuf> {
+        self.config.certificate_path = Some(certificate_path.into());
+        self
+    }
+
+    /// Sets a custom private key path. The path is required to be provided as a partial path
+    /// relative to the PKI directory. If set, this path will be used to read the private key
+    /// from disk.
+    pub fn private_key_path<T>(mut self, private_key_path: T) -> Self where T: Into<PathBuf> {
+        self.config.private_key_path = Some(private_key_path.into());
+        self
+    }
+
     /// Sets whether the client should automatically trust servers. If this is not set then
     /// the client will reject the server upon first connect and the server's certificate
     /// must be manually moved from pki's `/rejected` folder to the `/trusted` folder. If it is
@@ -197,9 +213,11 @@ fn client_builder() {
     let b = ClientBuilder::new()
         .application_name("appname")
         .application_uri("http://appname")
-        .trust_server_certs(true)
-        .create_sample_keypair(true)
         .product_uri("http://product")
+        .create_sample_keypair(true)
+        .certificate_path("certxyz")
+        .private_key_path("keyxyz")
+        .trust_server_certs(true)
         .pki_dir("pkixyz")
         .preferred_locales(vec!["a".to_string(), "b".to_string(), "c".to_string()])
         .default_endpoint("http://default")
@@ -213,9 +231,11 @@ fn client_builder() {
 
     assert_eq!(c.application_name, "appname");
     assert_eq!(c.application_uri, "http://appname");
-    assert_eq!(c.trust_server_certs, true);
-    assert_eq!(c.create_sample_keypair, true);
     assert_eq!(c.product_uri, "http://product");
+    assert_eq!(c.create_sample_keypair, true);
+    assert_eq!(c.certificate_path, Some(PathBuf::from("certxyz")));
+    assert_eq!(c.private_key_path, Some(PathBuf::from("keyxyz")));
+    assert_eq!(c.trust_server_certs, true);
     assert_eq!(c.pki_dir, PathBuf::from_str("pkixyz").unwrap());
     assert_eq!(c.preferred_locales, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
     assert_eq!(c.default_endpoint, "http://default");

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -117,7 +117,8 @@ impl Client {
     pub fn new(config: ClientConfig) -> Client {
         let application_description = if config.create_sample_keypair { Some(config.application_description()) } else { None };
 
-        let (mut certificate_store, client_certificate, client_pkey) = CertificateStore::new_with_keypair(&config.pki_dir, application_description);
+        let (mut certificate_store, client_certificate, client_pkey) = CertificateStore::new_with_keypair(
+            &config.pki_dir, config.certificate_path.as_deref(), config.private_key_path.as_deref(), application_description);
         if client_certificate.is_none() || client_pkey.is_none() {
             error!("Client is missing its application instance certificate and/or its private key. Encrypted endpoints will not function correctly.")
         }

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -124,17 +124,21 @@ pub struct ClientConfig {
     pub application_name: String,
     /// The application uri
     pub application_uri: String,
+    /// Product uri
+    pub product_uri: String,
     /// Autocreates public / private keypair if they don't exist. For testing/samples only
     /// since you do not have control of the values
     pub create_sample_keypair: bool,
+    /// Custom certificate path, to be used instead of the default .der certificate path
+    pub certificate_path: Option<PathBuf>,
+    /// Custom private key path, to be used instead of the default private key path
+    pub private_key_path: Option<PathBuf>,
     /// Auto trusts server certificates. For testing/samples only unless you're sure what you're
     /// doing.
     pub trust_server_certs: bool,
-    /// Product uri
-    pub product_uri: String,
-    /// pki folder, either absolute or relative to executable
+    /// PKI folder, either absolute or relative to executable
     pub pki_dir: PathBuf,
-    // Preferred locales
+    /// Preferred locales
     pub preferred_locales: Vec<String>,
     /// Identifier of the default endpoint
     pub default_endpoint: String,
@@ -224,15 +228,19 @@ impl Default for ClientConfig {
 }
 
 impl ClientConfig {
+    /// The default PKI directory
     pub const PKI_DIR: &'static str = "pki";
 
     pub fn new<T>(application_name: T, application_uri: T) -> Self where T: Into<String> {
         let mut pki_dir = std::env::current_dir().unwrap();
         pki_dir.push(Self::PKI_DIR);
+
         ClientConfig {
             application_name: application_name.into(),
             application_uri: application_uri.into(),
             create_sample_keypair: false,
+            certificate_path: None,
+            private_key_path: None,
             trust_server_certs: false,
             product_uri: String::new(),
             pki_dir,

--- a/client/src/tests/mod.rs
+++ b/client/src/tests/mod.rs
@@ -23,6 +23,10 @@ pub fn sample_builder() -> ClientBuilder {
     ClientBuilder::new()
         .application_name("OPC UA Sample Client")
         .application_uri("urn:SampleClient")
+        .create_sample_keypair(true)
+        .certificate_path("own/cert.der")
+        .private_key_path("private/private.pem")
+        .trust_server_certs(true)
         .pki_dir("./pki")
         .endpoints(vec![
             ("sample_none", ClientEndpoint {
@@ -51,8 +55,6 @@ pub fn sample_builder() -> ClientBuilder {
             })
         ])
         .default_endpoint("sample_none")
-        .create_sample_keypair(true)
-        .trust_server_certs(true)
         .user_token("sample_user", ClientUserToken::user_pass("sample1", "sample1pwd"))
         .user_token("sample_user2", ClientUserToken::user_pass("sample2", "sample2pwd"))
 }

--- a/crypto/src/tests/crypto.rs
+++ b/crypto/src/tests/crypto.rs
@@ -65,7 +65,7 @@ fn create_cert() {
 fn ensure_pki_path() {
     let (tmp_dir, cert_store) = make_certificate_store();
     let pki = cert_store.pki_path.clone();
-    for dirname in ["rejected", "trusted", "private", "own"].iter() {
+    for dirname in ["rejected", "trusted"].iter() {
         let mut subdir = pki.to_path_buf();
         subdir.push(dirname);
         assert!(subdir.exists());

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -1,9 +1,11 @@
 ---
 application_name: OPC UA Sample Client
 application_uri: "urn:SampleClient"
-create_sample_keypair: true
-trust_server_certs: true
 product_uri: ""
+create_sample_keypair: true
+certificate_path: own/cert.der
+private_key_path: private/private.pem
+trust_server_certs: true
 pki_dir: "./pki"
 preferred_locales: []
 default_endpoint: sample_none

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -2,9 +2,11 @@
 application_name: OPC UA Sample Server
 application_uri: "urn:OPC UA Sample Server"
 product_uri: "urn:OPC UA Sample Server Testkit"
-pki_dir: "./pki"
 create_sample_keypair: true
+certificate_path: own/cert.der
+private_key_path: private/private.pem
 trust_client_certs: false
+pki_dir: "./pki"
 discovery_server_url: "opc.tcp://localhost:4840/UADiscovery"
 tcp_config:
   hello_timeout: 5

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -61,6 +61,9 @@ impl ServerBuilder {
             .application_uri("urn:OPC UA Sample Server")
             .product_uri("urn:OPC UA Sample Server Testkit")
             .create_sample_keypair(true)
+            .certificate_path("own/cert.der")
+            .private_key_path("private/private.pem")
+            .pki_dir("./pki")
             .discovery_server_url(Some(constants::DEFAULT_DISCOVERY_SERVER_URL.to_string()))
             .user_token("sample_password_user", ServerUserToken {
                 user: "sample1".to_string(),
@@ -145,6 +148,22 @@ impl ServerBuilder {
     /// directory.
     pub fn create_sample_keypair(mut self, create_sample_keypair: bool) -> Self {
         self.config.create_sample_keypair = create_sample_keypair;
+        self
+    }
+
+    /// Sets a custom server certificate path. The path is required to be provided as a partial
+    /// path relative to the PKI directory. If set, this path will be used to read the server
+    /// certificate from disk. The certificate can be in either the .der or .pem format.
+    pub fn certificate_path<T>(mut self, certificate_path: T) -> Self where T: Into<PathBuf> {
+        self.config.certificate_path = Some(certificate_path.into());
+        self
+    }
+
+    /// Sets a custom private key path. The path is required to be provided as a partial path
+    /// relative to the PKI directory. If set, this path will be used to read the private key
+    /// from disk.
+    pub fn private_key_path<T>(mut self, private_key_path: T) -> Self where T: Into<PathBuf> {
+        self.config.private_key_path = Some(private_key_path.into());
         self
     }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -116,7 +116,8 @@ impl Server {
 
         // Security, pki auto create cert
         let application_description = if config.create_sample_keypair { Some(config.application_description()) } else { None };
-        let (mut certificate_store, server_certificate, server_pkey) = CertificateStore::new_with_keypair(&config.pki_dir, application_description);
+        let (mut certificate_store, server_certificate, server_pkey) = CertificateStore::new_with_keypair(
+            &config.pki_dir, config.certificate_path.as_deref(), config.private_key_path.as_deref(), application_description);
         if server_certificate.is_none() || server_pkey.is_none() {
             error!("Server is missing its application instance certificate and/or its private key. Encrypted endpoints will not function correctly.")
         }

--- a/tools/certificate-creator/src/main.rs
+++ b/tools/certificate-creator/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
             eprintln!("Certificate creation failed, check above for errors");
         } else {
             println!("Certificate and private key have been written to {} and {}",
-                     cert_store.own_cert_path().to_string_lossy(), cert_store.own_private_key_path().to_string_lossy());
+                     cert_store.own_certificate_path().display(), cert_store.own_private_key_path().display());
         }
     }
 }


### PR DESCRIPTION
We have a setup where we need to use specific client certificates which are fetched from a remote API during startup. These certs are in`PEM` format, so that wasn't possible with the current code. I tried to keep things as inline with the existing code as possible and made sure that the defaults would not change anything.

Additionally I made a small tweak to how certs are written to disk. The (3rd party) OPC server we connect to returns a certificate path which looks like `%BRAND%/UA Server [%UUID%].der`. So in order for this cert to be able to be saved, the directories `trusted/%BRAND%` need to exist. So now when writing a certificate to disk, the path needed is always being created just before writing the cert.

I hope this PR fits your style and vision and that this can be merged. Please let me know if you have any concerns or comments that need to be resolved first.

Thanks!