### PR TITLE
Use the current thread runtime for Tokio tasks

### DIFF
--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -236,6 +236,13 @@ impl ClientBuilder {
         self.config.session_timeout = session_timeout;
         self
     }
+
+    /// Configures the client to use a single-threaded executor. The default executor uses a
+    /// thread pool with a worker thread for each CPU core available on the system.
+    pub fn single_threaded_executor(mut self) -> Self {
+        self.config.single_threaded_executor = true;
+        self
+    }
 }
 
 #[test]
@@ -257,6 +264,7 @@ fn client_builder() {
         .session_retry_interval(1234)
         .session_retry_limit(999)
         .session_timeout(777)
+        .single_threaded_executor()
         // TODO user tokens, endpoints
         ;
 
@@ -278,4 +286,5 @@ fn client_builder() {
     assert_eq!(c.session_retry_interval, 1234);
     assert_eq!(c.session_retry_limit, 999);
     assert_eq!(c.session_timeout, 777);
+    assert_eq!(c.single_threaded_executor, true);
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -388,6 +388,7 @@ impl Client {
                 self.certificate_store.clone(),
                 session_info,
                 self.session_retry_policy.clone(),
+                self.config.single_threaded_executor,
             )));
             Ok(session)
         }
@@ -461,6 +462,7 @@ impl Client {
                 self.certificate_store.clone(),
                 session_info,
                 self.session_retry_policy.clone(),
+                self.config.single_threaded_executor,
             );
             session.connect()?;
             let result = session.get_endpoints()?;

--- a/client/src/comms/tcp_transport.rs
+++ b/client/src/comms/tcp_transport.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use futures::future::{self};
+use futures::future;
 use futures::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use futures::{Future, Stream};
 use tokio;
@@ -236,6 +236,8 @@ pub(crate) struct TcpTransport {
     connection_state: Arc<RwLock<ConnectionState>>,
     /// Message queue for requests / responses
     message_queue: Arc<RwLock<MessageQueue>>,
+    /// Use a single-threaded executor
+    single_threaded_executor: bool,
 }
 
 impl Drop for TcpTransport {
@@ -254,6 +256,7 @@ impl TcpTransport {
         secure_channel: Arc<RwLock<SecureChannel>>,
         session_state: Arc<RwLock<SessionState>>,
         message_queue: Arc<RwLock<MessageQueue>>,
+        single_threaded_executor: bool,
     ) -> TcpTransport {
         let connection_state = {
             let session_state = trace_read_lock_unwrap!(session_state);
@@ -264,6 +267,7 @@ impl TcpTransport {
             secure_channel,
             connection_state,
             message_queue,
+            single_threaded_executor,
         }
     }
 
@@ -314,6 +318,7 @@ impl TcpTransport {
 
             let connection_state = self.connection_state.clone();
             let session_state = self.session_state.clone();
+            let single_threaded_executor = self.single_threaded_executor;
 
             let _ = Some(thread::spawn(move || {
                 debug!("Client tokio tasks are starting for connection");
@@ -321,7 +326,11 @@ impl TcpTransport {
                 let thread_id = format!("client-connection-thread-{:?}", thread::current().id());
                 register_runtime_component!(thread_id.clone());
 
-                tokio::run(connection_task);
+                if !single_threaded_executor {
+                    tokio::runtime::run(connection_task);
+                } else {
+                    tokio::runtime::current_thread::run(connection_task);
+                }
                 debug!("Client tokio tasks have stopped for connection");
 
                 // Tell the session that the connection is finished.

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -163,6 +163,9 @@ pub struct ClientConfig {
     pub session_retry_interval: u32,
     /// Session timeout period in milliseconds
     pub session_timeout: u32,
+    /// Use a single-threaded executor. The default executor uses a thread pool with a worker
+    /// thread for each CPU core available on the system.
+    pub single_threaded_executor: bool,
 }
 
 impl Config for ClientConfig {
@@ -290,6 +293,7 @@ impl ClientConfig {
             session_retry_limit: SessionRetryPolicy::DEFAULT_RETRY_LIMIT as i32,
             session_retry_interval: SessionRetryPolicy::DEFAULT_RETRY_INTERVAL_MS,
             session_timeout: 0,
+            single_threaded_executor: false,
         }
     }
 }

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -139,6 +139,8 @@ pub struct Session {
     message_queue: Arc<RwLock<MessageQueue>>,
     /// Session retry policy.
     session_retry_policy: SessionRetryPolicy,
+    /// Use a single-threaded executor.
+    single_threaded_executor: bool,
 }
 
 impl Drop for Session {
@@ -167,6 +169,7 @@ impl Session {
         certificate_store: Arc<RwLock<CertificateStore>>,
         session_info: SessionInfo,
         session_retry_policy: SessionRetryPolicy,
+        single_threaded_executor: bool,
     ) -> Session {
         // TODO take these from the client config
         let decoding_limits = DecodingLimits::default();
@@ -185,11 +188,13 @@ impl Session {
             secure_channel.clone(),
             session_state.clone(),
             message_queue.clone(),
+            single_threaded_executor,
         );
         let subscription_state = Arc::new(RwLock::new(SubscriptionState::new()));
         let timer_command_queue = SubscriptionTimer::make_timer_command_queue(
             session_state.clone(),
             subscription_state.clone(),
+            single_threaded_executor,
         );
         Session {
             application_description,
@@ -202,6 +207,7 @@ impl Session {
             secure_channel,
             message_queue,
             session_retry_policy,
+            single_threaded_executor,
         }
     }
 
@@ -229,12 +235,14 @@ impl Session {
             self.secure_channel.clone(),
             self.session_state.clone(),
             self.message_queue.clone(),
+            self.single_threaded_executor,
         );
 
         // Create a new timer command queue
         self.timer_command_queue = SubscriptionTimer::make_timer_command_queue(
             self.session_state.clone(),
             self.subscription_state.clone(),
+            self.single_threaded_executor,
         );
     }
 
@@ -1124,10 +1132,15 @@ impl Session {
                 error!("Session activity timer task error = {:?}", err);
             });
 
+        let single_threaded_executor = self.single_threaded_executor;
         let _ = thread::spawn(move || {
             let thread_id = format!("session-activity-thread-{:?}", thread::current().id());
             register_runtime_component!(thread_id.clone());
-            tokio::run(task);
+            if !single_threaded_executor {
+                tokio::runtime::run(task);
+            } else {
+                tokio::runtime::current_thread::run(task);
+            }
             deregister_runtime_component!(thread_id.clone());
         });
     }

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -40,3 +40,4 @@ endpoints:
 session_retry_limit: 10
 session_retry_interval: 10000
 session_timeout: 0
+single_threaded_executor: false

--- a/samples/demo-server/src/main.rs
+++ b/samples/demo-server/src/main.rs
@@ -82,6 +82,7 @@ fn start_http_server(server: &Server) {
     let server_state = server.server_state();
     let connections = server.connections();
     let metrics = server.server_metrics();
+    let single_threaded_executor = server.single_threaded_executor();
     // The index.html is in a path relative to the working dir.
     let _ = http::run_http_server(
         "127.0.0.1:8585",
@@ -89,5 +90,6 @@ fn start_http_server(server: &Server) {
         server_state,
         connections,
         metrics,
+        single_threaded_executor,
     );
 }

--- a/samples/server.conf
+++ b/samples/server.conf
@@ -154,3 +154,4 @@ endpoints:
       - ANONYMOUS
       - sample_password_user
       - sample_x509_user
+single_threaded_executor: false

--- a/server/src/builder.rs
+++ b/server/src/builder.rs
@@ -351,4 +351,11 @@ impl ServerBuilder {
         self.config.limits.clients_can_modify_address_space = true;
         self
     }
+
+    /// Configures the server to use a single-threaded executor. The default executor uses a
+    /// thread pool with a worker thread for each CPU core available on the system.
+    pub fn single_threaded_executor(mut self) -> Self {
+        self.config.single_threaded_executor = true;
+        self
+    }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -517,6 +517,9 @@ pub struct ServerConfig {
     pub default_endpoint: Option<String>,
     /// Endpoints supported by the server
     pub endpoints: BTreeMap<String, ServerEndpoint>,
+    /// Use a single-threaded executor. The default executor uses a thread pool with a worker
+    /// thread for each CPU core available on the system.
+    pub single_threaded_executor: bool,
 }
 
 impl Config for ServerConfig {
@@ -621,6 +624,7 @@ impl Default for ServerConfig {
             discovery_urls: Vec::new(),
             default_endpoint: None,
             endpoints: BTreeMap::new(),
+            single_threaded_executor: false,
         }
     }
 }
@@ -671,6 +675,7 @@ impl ServerConfig {
             discovery_urls,
             default_endpoint: None,
             endpoints,
+            single_threaded_executor: false,
         }
     }
 


### PR DESCRIPTION
The default runtime is a threaded runtime which spawns a background
thread running a reactor instance and then creates a threadpool (with
the number of threads equal the the number of available CPU cores).

Now this creates a lot of threads, especially when multiple runtimes
are started, like in the client package. And while having a lot of
threads should not be a problem, Tokio needs to be able to communicate
between these threads so it (on Linux) creates unix pipes for that.
On an 16 core machine this resulted in around 144 handles per client.

On our system and the way we use multiple clients in our application
this caused us to hit the 1024 default open file handle limit. In most
cases that limit can easily be updated, but in our case that isn't an
option/solution. So I went looking at the code to see if there was an
"easy" fix and it seems there is one... As all the runtimes that are
created are actually created inside new dedicated threads, it seems
that using that single thread for the new runtime is a more efficient
solution which seems to be inline with how things were intended to
work.

I made the required changes in this PR and hope this is indeed inline
with how you intended to use Tokio. I excluded the runtime in the main
`run_server` function as I can imagine in that particular case it could
make sense to use a threaded runtime (now sure, can of cause make the
change for this one as well if you want).

Super curious what you think about this and if this is an acceptable PR.