### PR TITLE
Add option to skip additional certificate validations

### DIFF
--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -157,6 +157,15 @@ impl ClientBuilder {
         self
     }
 
+    /// Sets whether the client should verify server certificates. Regardless of this setting,
+    /// server certificates are always checked to see if they are trusted and have a valid key
+    /// length. In addition (if `verify_server_certs` is unset or is set to `true`) it will
+    /// verify the hostname, application uri and the not before / after values to ensure validity.
+    pub fn verify_server_certs(mut self, verify_server_certs: bool) -> Self {
+        self.config.verify_server_certs = verify_server_certs;
+        self
+    }
+
     /// Sets the pki directory where client's own key pair is stored and where `/trusted` and
     /// `/rejected` server certificates are stored.
     pub fn pki_dir<T>(mut self, pki_dir: T) -> Self
@@ -251,6 +260,7 @@ fn client_builder() {
         .certificate_path("certxyz")
         .private_key_path("keyxyz")
         .trust_server_certs(true)
+        .verify_server_certs(false)
         .pki_dir("pkixyz")
         .preferred_locales(vec!["a".to_string(), "b".to_string(), "c".to_string()])
         .default_endpoint("http://default")
@@ -269,6 +279,7 @@ fn client_builder() {
     assert_eq!(c.certificate_path, Some(PathBuf::from("certxyz")));
     assert_eq!(c.private_key_path, Some(PathBuf::from("keyxyz")));
     assert_eq!(c.trust_server_certs, true);
+    assert_eq!(c.verify_server_certs, false);
     assert_eq!(c.pki_dir, PathBuf::from_str("pkixyz").unwrap());
     assert_eq!(
         c.preferred_locales,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -130,10 +130,11 @@ impl Client {
             error!("Client is missing its application instance certificate and/or its private key. Encrypted endpoints will not function correctly.")
         }
 
+        // Clients may choose to skip additional server certificate validations
+        certificate_store.skip_verify_certs = !config.verify_server_certs;
+
         // Clients may choose to auto trust servers to save some messing around with rejected certs
-        if config.trust_server_certs {
-            certificate_store.trust_unknown_certs = true;
-        }
+        certificate_store.trust_unknown_certs = config.trust_server_certs;
 
         let session_timeout = config.session_timeout as f64;
 

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -147,6 +147,9 @@ pub struct ClientConfig {
     /// Auto trusts server certificates. For testing/samples only unless you're sure what you're
     /// doing.
     pub trust_server_certs: bool,
+    /// Verify server certificates. For testing/samples only unless you're sure what you're
+    /// doing.
+    pub verify_server_certs: bool,
     /// PKI folder, either absolute or relative to executable
     pub pki_dir: PathBuf,
     /// Preferred locales
@@ -281,6 +284,7 @@ impl ClientConfig {
             certificate_path: None,
             private_key_path: None,
             trust_server_certs: false,
+            verify_server_certs: true,
             product_uri: String::new(),
             pki_dir,
             preferred_locales: Vec::new(),

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -6,6 +6,7 @@ create_sample_keypair: true
 certificate_path: own/cert.der
 private_key_path: private/private.pem
 trust_server_certs: true
+verify_server_certs: true
 pki_dir: "./pki"
 preferred_locales: []
 default_endpoint: sample_none


### PR DESCRIPTION
This option is sometimes also called `ssl-no-verify` and allows clients to accept certificates that have incorrect values.

We need to connect to a lot of endpoints that we cannot manage ourselves and we get all kinds of errors with the certificates. Fixing those errors is difficult as we do not always have the required access ourselves, yet the endpoints are all 100% trusted. So this options allows us to connect dispite of those errors.