### PR TITLE
Make sure to disonnect a failed session

### DIFF
--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -706,6 +706,7 @@ impl Session {
                             "Reconnect was unsuccessful, retries = {}",
                             self.session_retry_policy.retry_count()
                         );
+                        self.disconnect();
                     }
                     true
                 }


### PR DESCRIPTION
Without calling disconnect here, the session can end up in an endless loop. This happens when creating the session succeeded, but the activation failed.

See here some log output that shows an example of this happening: https://gist.github.com/svanharmelen/3f1e52374ccce8bf023dd37bee562a6e

After this explicit `self.disconnect()`, the session is able to recover and reconnect in the next attempt. Not sure if `disconnect()` is the best call for this, but it seems like a good option/solution. If not then please advice what can/should be used instead.