### PR TITLE
Always use the supplied hostname when connecting

### DIFF
--- a/core/src/comms/url.rs
+++ b/core/src/comms/url.rs
@@ -34,21 +34,6 @@ pub fn url_with_replaced_hostname(url: &str, hostname: &str) -> Result<String, (
     Ok(url.into_string())
 }
 
-/// Test if the two urls match exactly. Strings are fed into a url parser and compared to resolve
-/// ambiguities like paths, case sensitive portions, encoding etc.
-pub fn url_matches(url1: &str, url2: &str) -> bool {
-    if let Ok(url1) = opc_url_from_str(url1) {
-        if let Ok(url2) = opc_url_from_str(url2) {
-            return url1 == url2;
-        } else {
-            error!("Cannot parse url \"{}\"", url2);
-        }
-    } else {
-        error!("Cannot parse url \"{}\"", url1);
-    }
-    false
-}
-
 /// Test if the two urls match except for the hostname. Can be used by a server whose endpoint doesn't
 /// exactly match the incoming connection, e.g. 127.0.0.1 vs localhost.
 pub fn url_matches_except_host(url1: &str, url2: &str) -> bool {
@@ -136,9 +121,6 @@ mod tests {
 
     #[test]
     fn url_matches_test() {
-        assert!(url_matches("opc.tcp://foo/", "opc.tcp://foo:4840/"));
-        assert!(!url_matches("opc.tcp://foo/", "opc.tcp://foo:4841/"));
-        assert!(!url_matches("opc.tcp://foo/xyz", "opc.tcp://bar/xyz"));
         assert!(url_matches_except_host(
             "opc.tcp://localhost/xyz",
             "opc.tcp://127.0.0.1/xyz"


### PR DESCRIPTION
When you use the function `connect_to_endpoint_id` the code uses a function called `find_matching_endpoint` which substitutes the advertised hostname with the one the client supplied.

But when using `connect_to_endpoint` it uses a function called `find_server_endpoint` which does successfully match even if the hostname is different, but in that case it doesn’t substitute the advertised hostname.

This can cause issues when using IP addresses i.c.w. a NAT connection, have a difference in the actual hostname vs the used DNS name or when the server uses a hostname that is not resolvable so you need to connect using an IP address.

It seems this was also an issue with `connect_to_endpoint_id` as there is a mention of this in the code:

```
// Issue #16, #17 - the server may advertise an endpoint whose hostname is inaccessible
// to the client so substitute the advertised hostname with the one the client supplied.
```

So I figured we could just update the code to use that same code path in `connect_to_endpoint` as well. Hope this is indeed OK and that there isn’t a specific reason for not allowing this when using `connect_to_endpoint`.

Thanks!