### PR TITLE
Make sure to register the new subscription

### DIFF
--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -2466,6 +2466,12 @@ impl Session {
                 callback,
             );
 
+            // Add the new subscription to the subscription state
+            {
+                let mut subscription_state = trace_write_lock_unwrap!(self.subscription_state);
+                subscription_state.add_subscription(subscription);
+            }
+
             // Send an async publish request for this new subscription
             {
                 let mut session_state = trace_write_lock_unwrap!(self.session_state);


### PR DESCRIPTION
This seems to have been lost in the last changes, so adding it back to make `master` work again 😉 