### PR TITLE
Allow the client to use the server time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,6 @@ dependencies = [
  "opcua-types",
  "serde",
  "serde_derive",
- "time",
  "tokio",
  "tokio-codec",
  "tokio-io",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -22,7 +22,6 @@ vendored-openssl = ["opcua-core/vendored-openssl"]
 [dependencies]
 log = "0.4"
 chrono = "0.4"
-time = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
 tokio = "0.1"

--- a/client/src/builder.rs
+++ b/client/src/builder.rs
@@ -225,7 +225,7 @@ impl ClientBuilder {
         self
     }
 
-    /// Sets the session retry limit
+    /// Sets the session retry limit.
     pub fn session_retry_limit(mut self, session_retry_limit: i32) -> Self {
         if session_retry_limit < 0 && session_retry_limit != -1 {
             panic!("Session retry limit must be -1, 0 or a positive number");
@@ -234,15 +234,22 @@ impl ClientBuilder {
         self
     }
 
-    /// Sets the session retry limit
+    /// Sets the session retry interval.
     pub fn session_retry_interval(mut self, session_retry_interval: u32) -> Self {
         self.config.session_retry_interval = session_retry_interval;
         self
     }
 
-    /// Sets the session timeout period
+    /// Sets the session timeout period.
     pub fn session_timeout(mut self, session_timeout: u32) -> Self {
         self.config.session_timeout = session_timeout;
+        self
+    }
+
+    /// Sets whether the client should ignore clock skew so the client can make a successful
+    /// connection to the server, even when the client and server clocks are out of sync.
+    pub fn ignore_clock_skew(mut self) -> Self {
+        self.config.performance.ignore_clock_skew = true;
         self
     }
 
@@ -283,6 +290,7 @@ fn client_builder() {
         .session_retry_interval(1234)
         .session_retry_limit(999)
         .session_timeout(777)
+        .ignore_clock_skew()
         .single_threaded_executor()
         .session_name("SessionName")
         // TODO user tokens, endpoints
@@ -307,6 +315,7 @@ fn client_builder() {
     assert_eq!(c.session_retry_interval, 1234);
     assert_eq!(c.session_retry_limit, 999);
     assert_eq!(c.session_timeout, 777);
+    assert_eq!(c.performance.ignore_clock_skew, true);
     assert_eq!(c.performance.single_threaded_executor, true);
     assert_eq!(c.session_name, "SessionName");
 }

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -391,6 +391,7 @@ impl Client {
                 self.certificate_store.clone(),
                 session_info,
                 self.session_retry_policy.clone(),
+                self.config.performance.ignore_clock_skew,
                 self.config.performance.single_threaded_executor,
             )));
             Ok(session)
@@ -466,6 +467,7 @@ impl Client {
                 self.certificate_store.clone(),
                 session_info,
                 self.session_retry_policy.clone(),
+                self.config.performance.ignore_clock_skew,
                 self.config.performance.single_threaded_executor,
             );
             session.connect()?;

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -130,6 +130,9 @@ impl ClientEndpoint {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize, Clone)]
 pub struct Performance {
+    /// Ignore clock skew allows the client to make a successful connection to the server, even
+    /// when the client and server clocks are out of sync.
+    pub ignore_clock_skew: bool,
     /// Use a single-threaded executor. The default executor uses a thread pool with a worker
     /// thread for each CPU core available on the system.
     pub single_threaded_executor: bool,
@@ -306,6 +309,7 @@ impl ClientConfig {
             session_retry_interval: SessionRetryPolicy::DEFAULT_RETRY_INTERVAL_MS,
             session_timeout: 0,
             performance: Performance {
+                ignore_clock_skew: false,
                 single_threaded_executor: false,
             },
             session_name: "Rust OPC UA Client".into(),

--- a/core/src/tests/chunk.rs
+++ b/core/src/tests/chunk.rs
@@ -96,7 +96,8 @@ fn chunk_multi_encode_decode() {
     let _ = Test::setup();
 
     let mut secure_channel = SecureChannel::new_no_certificate_store();
-    secure_channel.set_(DecodingLimits {
+    secure_channel.set_decoding_limits(DecodingLimits {
+        client_offset: chrono::Duration::zero(),
         max_chunk_count: 0,
         max_string_length: 65535,
         max_byte_string_length: 65535,

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -42,5 +42,6 @@ session_retry_limit: 10
 session_retry_interval: 10000
 session_timeout: 0
 performance:
+  ignore_clock_skew: false
   single_threaded_executor: false
 session_name: Rust OPC UA Client

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -694,6 +694,7 @@ impl ServerConfig {
 
     pub fn decoding_limits(&self) -> DecodingLimits {
         DecodingLimits {
+            client_offset: chrono::Duration::zero(),
             max_chunk_count: 0,
             max_string_length: self.limits.max_string_length as usize,
             max_byte_string_length: self.limits.max_byte_string_length as usize,

--- a/server/src/metrics.rs
+++ b/server/src/metrics.rs
@@ -14,7 +14,7 @@ use crate::{
     diagnostics::ServerDiagnostics,
     server,
     state::ServerState,
-    subscriptions::subscriptions::{self},
+    subscriptions::subscriptions,
 };
 
 #[derive(Serialize)]

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -9,7 +9,7 @@ use std::{
     },
 };
 
-use chrono::{self, Utc};
+use chrono::Utc;
 
 use opcua_core::comms::secure_channel::{Role, SecureChannel};
 use opcua_crypto::X509;

--- a/types/src/data_value.rs
+++ b/types/src/data_value.rs
@@ -126,7 +126,12 @@ impl BinaryEncoder<DataValue> for DataValue {
         };
         // Source timestamp
         let source_timestamp = if encoding_mask.contains(DataValueFlags::HAS_SOURCE_TIMESTAMP) {
-            Some(DateTime::decode(stream, decoding_limits)?)
+            // The source timestamp should never be adjusted, not even when ignoring clock skew
+            let decoding_limits = DecodingLimits {
+                client_offset: chrono::Duration::zero(),
+                ..*decoding_limits
+            };
+            Some(DateTime::decode(stream, &decoding_limits)?)
         } else {
             None
         };

--- a/types/src/encoding.rs
+++ b/types/src/encoding.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
+use chrono::Duration;
 
 use crate::{constants, status_codes::StatusCode};
 
@@ -19,6 +20,9 @@ pub type EncodingResult<T> = std::result::Result<T, StatusCode>;
 
 #[derive(Clone, Copy, Debug)]
 pub struct DecodingLimits {
+    /// Time offset between the client and the server, only used by the client when it's configured
+    /// to ignore time skew.
+    pub client_offset: Duration,
     /// Maximum size of a message chunk in bytes. 0 means no limit
     pub max_chunk_count: usize,
     /// Maximum length in bytes (not chars!) of a string. 0 actually means 0, i.e. no string permitted
@@ -32,6 +36,7 @@ pub struct DecodingLimits {
 impl Default for DecodingLimits {
     fn default() -> Self {
         DecodingLimits {
+            client_offset: Duration::zero(),
             max_chunk_count: 0,
             max_string_length: constants::MAX_STRING_LENGTH,
             max_byte_string_length: constants::MAX_BYTE_STRING_LENGTH,
@@ -45,6 +50,7 @@ impl DecodingLimits {
     /// any string or array.
     pub fn minimal() -> Self {
         DecodingLimits {
+            client_offset: Duration::zero(),
             max_chunk_count: 0,
             max_string_length: 0,
             max_byte_string_length: 0,


### PR DESCRIPTION
In some situations, were the server setup is managed by a 3rd party, it can be needed to “follow” the server time in the client in order to be able to setup a connection.

This solution is pretty much inline with what is documented [here](https://reference.opcfoundation.org/v104/Core/docs/Part6/6.3/), except in this solution only the time used in the client is adjusted and the host clock is left untouched.

And just to be clear, the offset is only used for the communication and security related parts between the client and the server. For the rest the actuall time will still be used.

I tested this against several 3rd party server and the change resulted in stable connections without any errors, reconnects or constantly renewing security channels.

Fixes #89