### PR TITLE
Fix username/password authentication

### DIFF
--- a/core/src/comms/secure_channel.rs
+++ b/core/src/comms/secure_channel.rs
@@ -283,22 +283,12 @@ impl SecureChannel {
 
     /// Set their nonce which should be the same as the symmetric key
     pub fn set_remote_nonce_from_byte_string(&mut self, remote_nonce: &ByteString) -> Result<(), StatusCode> {
-        if self.security_policy != SecurityPolicy::None && (self.security_mode == MessageSecurityMode::Sign || self.security_mode == MessageSecurityMode::SignAndEncrypt) {
-            if let Some(ref remote_nonce) = remote_nonce.value {
-                if remote_nonce.len() != self.security_policy.secure_channel_nonce_length() {
-                    error!("Remote nonce is invalid length {}, expecting {}. {:?}", remote_nonce.len(), self.security_policy.secure_channel_nonce_length(), remote_nonce);
-                    Err(StatusCode::BadNonceInvalid)
-                } else {
-                    self.remote_nonce = remote_nonce.to_vec();
-                    Ok(())
-                }
-            } else {
-                error!("Remote nonce is invalid {:?}", remote_nonce);
-                Err(StatusCode::BadNonceInvalid)
-            }
-        } else {
-            trace!("set_remote_nonce is doing nothing because security policy = {:?}, mode = {:?}", self.security_policy, self.security_mode);
+        if let Some(ref remote_nonce) = remote_nonce.value {
+            self.remote_nonce = remote_nonce.to_vec();
             Ok(())
+        } else {
+            error!("Remote nonce is invalid {:?}", remote_nonce);
+            Err(StatusCode::BadNonceInvalid)
         }
     }
 

--- a/crypto/src/user_identity.rs
+++ b/crypto/src/user_identity.rs
@@ -35,7 +35,7 @@ pub fn make_user_name_identity_token(channel_security_policy: SecurityPolicy, us
 
     // Table 179 Opc Part 4 provides a table of which encryption algorithm to use
     let security_policy = if channel_security_policy == SecurityPolicy::None {
-        if user_token_policy.security_policy_uri.is_empty() || token_security_policy != SecurityPolicy::None {
+        if user_token_policy.security_policy_uri.is_empty() || token_security_policy == SecurityPolicy::None {
             SecurityPolicy::None
         } else {
             token_security_policy


### PR DESCRIPTION
This fixes two issues that combined caused the client to be unable to connect to our OPC-UA server (Kepware).

Here's a snippet from the GetEndpointsResponse that details the endpoint configuration
```
	0000000000:             messageSecurityMode: None 
	0000000000:             securityPolicyUri: http://opcfoundation.org/UA/SecurityPolicy#None 
	0000000000:             userIdentityTokens []: Size: 2 
	0000000000:                userIdentityTokens [ 0 ]: 
	0000000000:                   policyId: UserName 
	0000000000:                   tokenType: 1 
	0000000000:                   issuedTokenType: [empty] 
	0000000000:                   isssuerEndpointUrl: [empty] 
	0000000000:                   securityPolicyUri: http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15 
```

Overall, the two problems were:

 - The selected security policy for authentication was `None`, when it should be `Basic128Rsa15`
 - The server's nonce (remote nonce) was ignored 

## crypto/user_identity: Fix selection of security policy 

In `make_user_name_identity_token()` the security policy to use when
authenticating with username and password is determined from the
user_token_policy and token_security_policy.

In our tests, if the server provides eg. Basic128Rsa15 as the
user token policy, the logic would select None as the policy and
subsequently not encrypt the password and fail to connect.

Inverting some of the logic appears to work (at least for our tests).

## core/comms/secure_channel: Always set remote nonce

The set_remote_nonce_from_byte_string() performs some checks against the
message security mode.

In our tests, we use security policy = None and security mode = None,
but the server sets Basic126Rsa15 for the user identity token policy
meaning that we still need to use the server nonce for authentication.

This patch removes all the checking around security policy and mode,
which allows the client to connect to our OPC-UA server (Kepware)
successfully.