### PR TITLE
crypto: Properly select encryption algo from security policies

### DIFF
--- a/crypto/src/tests/authentication.rs
+++ b/crypto/src/tests/authentication.rs
@@ -111,8 +111,10 @@ fn user_name_identity_token_encrypted() {
         &password,
     )
     .unwrap();
-    assert!(token.encryption_algorithm.is_null());
-    assert_eq!(token.password.as_ref(), password.as_bytes());
+    assert_eq!(
+        token.encryption_algorithm.as_ref(),
+        crypto::algorithms::ENC_RSA_15
+    );
     let password1 = decrypt_user_identity_token_password(&token, nonce.as_ref(), &pkey).unwrap();
     assert_eq!(password, password1);
 


### PR DESCRIPTION
When calling the ActivateSession Service, the service should accept
UserIdentityToken. For the UserNameIdentityToken, we need to provide a
password and it can be the case that the password needs to be encrypted
even though the SecureChannel's SecurityPolicy is set to None.

This commit adjusts the selection of the EncryptionAlgorithm as outlined
in Table 187 Opc Part 4. In general, we should prefer the
UserTokenIdentity.SecurityPolicy, expect for when it's not specified.

See locka99/opcua#58