### PR TITLE
core/comms/secure_channel: Always set remote nonce

### DIFF
--- a/core/src/comms/secure_channel.rs
+++ b/core/src/comms/secure_channel.rs
@@ -311,34 +311,12 @@ impl SecureChannel {
         &mut self,
         remote_nonce: &ByteString,
     ) -> Result<(), StatusCode> {
-        if self.security_policy != SecurityPolicy::None
-            && (self.security_mode == MessageSecurityMode::Sign
-                || self.security_mode == MessageSecurityMode::SignAndEncrypt)
-        {
-            if let Some(ref remote_nonce) = remote_nonce.value {
-                if remote_nonce.len() != self.security_policy.secure_channel_nonce_length() {
-                    error!(
-                        "Remote nonce is invalid length {}, expecting {}. {:?}",
-                        remote_nonce.len(),
-                        self.security_policy.secure_channel_nonce_length(),
-                        remote_nonce
-                    );
-                    Err(StatusCode::BadNonceInvalid)
-                } else {
-                    self.remote_nonce = remote_nonce.to_vec();
-                    Ok(())
-                }
-            } else {
-                error!("Remote nonce is invalid {:?}", remote_nonce);
-                Err(StatusCode::BadNonceInvalid)
-            }
-        } else {
-            trace!(
-                "set_remote_nonce is doing nothing because security policy = {:?}, mode = {:?}",
-                self.security_policy,
-                self.security_mode
-            );
+        if let Some(ref remote_nonce) = remote_nonce.value {
+            self.remote_nonce = remote_nonce.to_vec();
             Ok(())
+        } else {
+            error!("Remote nonce is invalid {:?}", remote_nonce);
+            Err(StatusCode::BadNonceInvalid)
         }
     }
 


### PR DESCRIPTION
The set_remote_nonce_from_byte_string() performs some checks against the
message security mode.

In our tests, we use security policy = None and security mode = None,
but the server sets Basic126Rsa15 for the user identity token policy
meaning that we still need to use the server nonce for authentication.

This patch removes all the checking around security policy and mode,
which allows the client to connect to our OPC-UA server (Kepware)
successfully.