### PR TITLE
decode null array

### DIFF
--- a/types/src/tests/encoding.rs
+++ b/types/src/tests/encoding.rs
@@ -481,3 +481,20 @@ fn argument() {
         description: LocalizedText::new("foo", "bar"),
     });
 }
+
+// test decoding of an null array  null != empty!
+#[test]
+fn null_array() -> EncodingResult<()>{
+    // @FIXME currently creating an null array via Array or Variant is not possible so do it by hand
+    let vec = Vec::new();
+    let mut stream = Cursor::new(vec);
+    let mask = EncodingMask::BOOLEAN | EncodingMask::ARRAY_MASK;
+    mask.encode(&mut stream)?;
+    let length = -1_i32;
+    length.encode(&mut stream)?;
+    let actual = stream.into_inner();
+    let mut stream = Cursor::new(actual);
+    let arr = Variant::decode(&mut stream, &DecodingOptions::default())?;
+    assert_eq!(arr, Variant::Array(Box::new(Array{ value_type: VariantTypeId::Boolean, values: Vec::new(), dimensions: Vec::new()})));
+    Ok(())
+}

--- a/types/src/variant.rs
+++ b/types/src/variant.rs
@@ -716,6 +716,13 @@ impl BinaryEncoder<Variant> for Variant {
         // Read array length
         let array_length = if encoding_mask & EncodingMask::ARRAY_VALUES_BIT != 0 {
             let array_length = i32::decode(stream, decoding_options)?;
+            // null array of type
+            if array_length == -1 {
+                return Ok(Variant::Array(Box::new(Array{
+                    value_type: VariantTypeId::from_encoding_mask(element_encoding_mask),
+                    values: Vec::new(),
+                    dimensions: Vec::new()})))
+            }
             if array_length <= 0 {
                 error!("Invalid array_length {}", array_length);
                 return Err(StatusCode::BadDecodingError);


### PR DESCRIPTION
Make it possible to decode a null array. See [Part6 5.2.5](https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.5/)