### PR TITLE
feat: use CloseSession request when disconnecting

### DIFF
--- a/client/src/session/session.rs
+++ b/client/src/session/session.rs
@@ -569,7 +569,7 @@ impl Session {
     /// or retrieve any existing subscriptions.
     pub fn disconnect(&self) {
         if self.is_connected() {
-            let _ = self.delete_all_subscriptions();
+            let _ = self.close_session_and_delete_subscriptions();
             let _ = self.close_secure_channel();
 
             {
@@ -946,6 +946,38 @@ impl Session {
                 "delete_all_subscriptions, called when there are no subscriptions"
             );
             Err(StatusCode::BadNothingToDo)
+        }
+    }
+
+    /// Closes the session and deletes all subscriptions
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - if the session was closed
+    /// * `Err(StatusCode)` - Status code reason for failure
+    ///
+    /// [`CloseSessionRequest`]: ./struct.CloseSessionRequest.html
+    ///
+    pub fn close_session_and_delete_subscriptions(&self) -> Result<(), StatusCode> {
+        if !self.is_connected() {
+            return Err(StatusCode::BadNotConnected);
+        }
+        let request = CloseSessionRequest {
+            delete_subscriptions: true,
+            request_header: self.make_request_header()
+        };
+        let response = self.send_request(request)?;
+        if let SupportedMessage::CloseSessionResponse(_) =  response {
+            let mut subscription_state = trace_write_lock_unwrap!(self.subscription_state);
+            if let Some(subscription_ids) = subscription_state.subscription_ids() {
+                for subscription_id in subscription_ids {
+                    subscription_state.delete_subscription(subscription_id);
+                }
+            }
+            Ok(())
+        } else {
+            session_error!(self, "close_session failed {:?}", response);
+            Err(crate::process_unexpected_response(response))
         }
     }
 


### PR DESCRIPTION
When using the library - excellent work, btw! :D - I noticed that the sessions would remain open in the OPC UA servers I was connecting to.

Since the current code was already deleting all subscriptions anyway, I decided to also add the [`CloseSession`](https://reference.opcfoundation.org/v104/Core/docs/Part4/5.6.4/) request.

One thing I'm not sure about is how to best test this - if you can give me a hint, I'll gladly do something about that.