### PR TITLE
Switch to parking_lot and fix Clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,9 +239,9 @@ checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
@@ -478,7 +478,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cfg-if 0.1.10",
  "crossbeam-utils 0.7.2",
  "lazy_static",
@@ -514,7 +514,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cfg-if 0.1.10",
  "lazy_static",
 ]
@@ -1019,7 +1019,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "hashbrown",
 ]
 
@@ -1142,10 +1142,11 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg 1.1.0",
  "scopeguard 1.1.0",
 ]
 
@@ -1238,7 +1239,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1274,7 +1275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1405,7 +1406,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "num-traits",
 ]
 
@@ -1415,7 +1416,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1469,6 +1470,7 @@ dependencies = [
  "log 0.4.14",
  "openssl",
  "openssl-sys",
+ "parking_lot 0.12.0",
  "regex",
  "rustc-serialize",
  "serde",
@@ -1496,6 +1498,7 @@ name = "opcua-chess-server"
 version = "0.11.0"
 dependencies = [
  "opcua",
+ "parking_lot 0.12.0",
  "uci",
 ]
 
@@ -1508,6 +1511,7 @@ dependencies = [
  "log 0.4.14",
  "log4rs",
  "opcua",
+ "parking_lot 0.12.0",
  "pico-args",
  "rand 0.7.3",
 ]
@@ -1525,6 +1529,7 @@ name = "opcua-event-client"
 version = "0.11.0"
 dependencies = [
  "opcua",
+ "parking_lot 0.12.0",
  "pico-args",
 ]
 
@@ -1535,6 +1540,7 @@ dependencies = [
  "chrono",
  "log 0.4.14",
  "opcua",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
@@ -1543,6 +1549,7 @@ version = "0.11.0"
 dependencies = [
  "futures 0.1.31",
  "opcua",
+ "parking_lot 0.12.0",
  "pico-args",
  "serde",
  "serde_derive",
@@ -1559,6 +1566,7 @@ name = "opcua-mqtt-client"
 version = "0.11.0"
 dependencies = [
  "opcua",
+ "parking_lot 0.12.0",
  "pico-args",
  "rumqtt",
 ]
@@ -1568,6 +1576,7 @@ name = "opcua-simple-client"
 version = "0.11.0"
 dependencies = [
  "opcua",
+ "parking_lot 0.12.0",
  "pico-args",
 ]
 
@@ -1578,6 +1587,7 @@ dependencies = [
  "chrono",
  "log 0.4.14",
  "opcua",
+ "parking_lot 0.12.0",
 ]
 
 [[package]]
@@ -1587,6 +1597,7 @@ dependencies = [
  "actix",
  "actix-web",
  "opcua",
+ "parking_lot 0.12.0",
  "pico-args",
  "serde",
  "serde_derive",
@@ -1629,7 +1640,7 @@ version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
- "autocfg 1.0.1",
+ "autocfg 1.1.0",
  "cc",
  "libc",
  "openssl-src",
@@ -1683,8 +1694,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.5",
+ "lock_api 0.4.7",
  "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
+dependencies = [
+ "lock_api 0.4.7",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1727,6 +1748,19 @@ dependencies = [
  "redox_syscall 0.2.10",
  "smallvec 1.7.0",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec 1.7.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3190,6 +3224,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "winreg"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2018"
 
 [dev-dependencies]
-log = "0.4"
 chrono = "0.4"
+log = "0.4"
+parking_lot = { version = "0.12", features = ["send_guard"] }
 
 [dev-dependencies.opcua]
 path = "../lib"

--- a/integration/src/tests.rs
+++ b/integration/src/tests.rs
@@ -1,13 +1,13 @@
 use std::{
-    sync::{mpsc, mpsc::channel, Arc, RwLock},
+    sync::{mpsc, mpsc::channel, Arc},
     thread,
 };
 
 use chrono::Utc;
 use log::*;
-
 use opcua::client::prelude::*;
 use opcua::server::prelude::*;
+use parking_lot::RwLock;
 
 use crate::harness::*;
 
@@ -139,7 +139,7 @@ fn server_abort() {
 
     {
         // Set the abort flag
-        server2.write().unwrap().abort();
+        server2.write().abort();
     }
 
     // Wait for the message or timeout to occur
@@ -423,7 +423,7 @@ fn read_write_read() {
 
             // Read the existing value
             {
-                let session = session.read().unwrap();
+                let session = session.read();
                 let results = session
                     .read(&[node_id.clone().into()], TimestampsToReturn::Both, 1.0)
                     .unwrap();
@@ -433,7 +433,7 @@ fn read_write_read() {
             }
 
             {
-                let session = session.read().unwrap();
+                let session = session.read();
                 let results = session
                     .write(&[WriteValue {
                         node_id: node_id.clone(),
@@ -447,7 +447,7 @@ fn read_write_read() {
             }
 
             {
-                let session = session.read().unwrap();
+                let session = session.read();
                 let results = session
                     .read(&[node_id.into()], TimestampsToReturn::Both, 1.0)
                     .unwrap();
@@ -456,7 +456,7 @@ fn read_write_read() {
             }
 
             {
-                let session = session.read().unwrap();
+                let session = session.read();
                 session.disconnect();
             }
         },
@@ -481,7 +481,7 @@ fn subscribe_1000() {
             let session = client
                 .connect_to_endpoint(client_endpoint, identity_token)
                 .unwrap();
-            let session = session.read().unwrap();
+            let session = session.read();
 
             let start_time = Utc::now();
 
@@ -558,7 +558,7 @@ fn method_call() {
             let session = client
                 .connect_to_endpoint(client_endpoint, IdentityToken::Anonymous)
                 .unwrap();
-            let session = session.read().unwrap();
+            let session = session.read();
 
             // Call the method
             let input_arguments = Some(vec![Variant::from("Foo")]);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,8 +5,8 @@ description = "OPC UA client and server API"
 authors = ["Adam Lock <locka99@gmail.com>"]
 homepage = "https://github.com/locka99/opcua"
 license = "MPL-2.0"
-keywords = ["opcua","opc","ua"]
-categories = ["embedded","network-programming"]
+keywords = ["opcua", "opc", "ua"]
+categories = ["embedded", "network-programming"]
 readme = "../README.md"
 documentation = "https://docs.rs/opcua/"
 edition = "2018"
@@ -19,60 +19,61 @@ travis-ci = { repository = "locka99/opcua" }
 appveyor = { repository = "locka99/opcua" }
 
 [features]
-default = ["server", "client"]
-all = ["server", "client", "console-logging", "http"]
-# Server default settings
-server = ["generated-address-space", "discovery-server-registration"]
-# Client default settings
+default = ["client", "server"]
+all = ["client", "server", "console-logging", "http"]
+# Client default settings.
 client = []
-# Console logging just installs a logger that writes out to the screen, useful for general logging
+# Server default settings.
+server = ["discovery-server-registration", "generated-address-space"]
+# Console logging just installs a logger that writes out to the screen, useful for general logging.
 console-logging = ["env_logger"]
-# Includes all the code to populate the address space with the default node set. This is something that embedded
-# systems may or may not require.
-generated-address-space = []
-# Allows a server to register itself with a local discovery server. It does so by becoming a client to the LDS,
-# which brings in a dependency to opcua-client. Omitting the feature saves some memory.
+# Allows a server to register itself with a local discovery server. It does so by becoming a client
+# to the LDS, which brings in a dependency to opcua-client. Omitting the feature saves some memory.
 discovery-server-registration = ["client"]
-# OpenSSL can be compiled and statically linked to with this feature
-vendored-openssl = ["openssl/vendored"]
-# Servers might want to show a web server with metric / diagnostic info
+# Includes all the code to populate the address space with the default node set. This is something
+# that embedded systems may or may not require.
+generated-address-space = []
+# Servers might want to show a web server with metric / diagnostic info.
 http = ["actix-web"]
+# OpenSSL can be compiled and statically linked to with this feature.
+vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
-log = "0.4"
+base64 = "0.12"
+bitflags = "1.2"
+byteorder = "1.3"
+bytes = "1.0.1"
 chrono = { version = "0.4", features = ["serde"] }
+derivative = "1.0"
+foreign-types = "0.3"
 futures = "0.3"
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.6", features = ["codec"] }
+gethostname = "0.2.1"
 lazy_static = "1.4.0"
+libc = "0.2"
+log = "0.4"
+openssl = "0.10"
+openssl-sys = "0.9"
+parking_lot = { version = "0.12", features = ["send_guard"] }
 regex = "1.3"
 serde = "1.0"
 serde_derive = "1.0"
-serde_yaml = "0.8"
 serde_json = "1.0"
-bytes = "1.0.1"
-url = "1.6"
+serde_yaml = "0.8"
 time = "0.1"
-bitflags = "1.2"
-derivative = "1.0"
-byteorder = "1.3"
-base64 = "0.12"
+tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.6", features = ["codec"] }
+url = "1.6"
 uuid = { version = "0.8", features = ["v4"] }
-openssl = "0.10"
-openssl-sys = "0.9"
-gethostname = "0.2.1"
-libc = "0.2"
-foreign-types = "0.3"
-
-[dependencies.env_logger]
-version = "0.5"
-optional = true
 
 [dependencies.actix-web]
 version = "0.7"
 optional = true
 
+[dependencies.env_logger]
+version = "0.5"
+optional = true
+
 [dev-dependencies]
-tempdir = "0.3"
-serde_json = "1.0"
 rustc-serialize = "0.3.24"
+serde_json = "1.0"
+tempdir = "0.3"

--- a/lib/src/client/builder.rs
+++ b/lib/src/client/builder.rs
@@ -15,40 +15,31 @@ use crate::core::config::Config;
 /// ```no_run
 /// use opcua::client::prelude::*;
 ///
-/// fn main() {
-///     let builder = ClientBuilder::new()
-///         .application_name("OPC UA Sample Client")
-///         .application_uri("urn:SampleClient")
-///         .pki_dir("./pki")
-///         .endpoints(vec![
-///             ("sample_endpoint", ClientEndpoint {
-///                 url: String::from("opc.tcp://127.0.0.1:4855/"),
-///                 security_policy: String::from(SecurityPolicy::None.to_str()),
-///                 security_mode: String::from(MessageSecurityMode::None),
-///                 user_token_id: ANONYMOUS_USER_TOKEN_ID.to_string(),
-///             }),
-///         ])
-///         .default_endpoint("sample_endpoint")
-///         .create_sample_keypair(true)
-///         .trust_server_certs(true)
-///         .user_token("sample_user", ClientUserToken::user_pass("sample1", "sample1pwd"));
-///     let client = builder.client().unwrap();
-/// }
+/// let builder = ClientBuilder::new()
+///     .application_name("OPC UA Sample Client")
+///     .application_uri("urn:SampleClient")
+///     .pki_dir("./pki")
+///     .endpoints(vec![
+///         ("sample_endpoint", ClientEndpoint {
+///             url: String::from("opc.tcp://127.0.0.1:4855/"),
+///             security_policy: String::from(SecurityPolicy::None.to_str()),
+///             security_mode: String::from(MessageSecurityMode::None),
+///             user_token_id: ANONYMOUS_USER_TOKEN_ID.to_string(),
+///         }),
+///     ])
+///     .default_endpoint("sample_endpoint")
+///     .create_sample_keypair(true)
+///     .trust_server_certs(true)
+///     .user_token("sample_user", ClientUserToken::user_pass("sample1", "sample1pwd"));
+/// let client = builder.client().unwrap();
 /// ```
 ///
 /// [`Client`]: ../client/struct.Client.html
 /// [`ClientConfig`]: ../config/struct.ClientConfig.html
 ///
+#[derive(Default)]
 pub struct ClientBuilder {
     config: ClientConfig,
-}
-
-impl Default for ClientBuilder {
-    fn default() -> Self {
-        ClientBuilder {
-            config: ClientConfig::default(),
-        }
-    }
 }
 
 impl ClientBuilder {

--- a/lib/src/client/config.rs
+++ b/lib/src/client/config.rs
@@ -79,17 +79,18 @@ impl ClientUserToken {
                 );
                 valid = false;
             }
-        } else {
-            if self.cert_path.is_none() && self.private_key_path.is_none() {
-                error!(
-                    "User token {} fails to provide a password or certificate info.",
-                    self.user
-                );
-                valid = false;
-            } else if self.cert_path.is_none() || self.private_key_path.is_none() {
-                error!("User token {} fails to provide both a certificate path and a private key path.", self.user);
-                valid = false;
-            }
+        } else if self.cert_path.is_none() && self.private_key_path.is_none() {
+            error!(
+                "User token {} fails to provide a password or certificate info.",
+                self.user
+            );
+            valid = false;
+        } else if self.cert_path.is_none() || self.private_key_path.is_none() {
+            error!(
+                "User token {} fails to provide both a certificate path and a private key path.",
+                self.user
+            );
+            valid = false;
         }
         valid
     }

--- a/lib/src/client/message_queue.rs
+++ b/lib/src/client/message_queue.rs
@@ -132,7 +132,7 @@ impl MessageQueue {
         let mut async_handles = self.responses.keys().copied().collect::<Vec<_>>();
 
         // Order them from oldest to latest (except if handles wrap)
-        async_handles.sort();
+        async_handles.sort_unstable();
 
         // Remove each item from the map and return to caller
         async_handles

--- a/lib/src/client/mod.rs
+++ b/lib/src/client/mod.rs
@@ -36,8 +36,10 @@
 //! described in the in docs/client.md tutorial.
 //!
 //! ```no_run
-//! use std::sync::{Arc, RwLock};
+//! use std::sync::Arc;
+//!
 //! use opcua::client::prelude::*;
+//! use parking_lot::RwLock;
 //!
 //! fn main() {
 //!     let mut client = ClientBuilder::new()
@@ -64,7 +66,7 @@
 //! }
 //!
 //! fn subscribe_to_values(session: Arc<RwLock<Session>>) -> Result<(), StatusCode> {
-//!     let mut session = session.write().unwrap();
+//!     let mut session = session.write();
 //!     // Create a subscription polling every 2s with a callback
 //!     let subscription_id = session.create_subscription(2000.0, 10, 30, 0, 0, true, DataChangeCallback::new(|changed_monitored_items| {
 //!         println!("Data change from server:");

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -6,12 +6,13 @@ use std::{
     sync::{
         atomic::{AtomicU32, Ordering},
         mpsc::{self, Receiver, SyncSender},
-        Arc, RwLock,
+        Arc,
     },
     u32,
 };
 
 use chrono::Duration;
+use parking_lot::RwLock;
 
 use tokio::time::Instant;
 

--- a/lib/src/client/subscription.rs
+++ b/lib/src/client/subscription.rs
@@ -15,8 +15,10 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     marker::Sync,
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
+
+use parking_lot::Mutex;
 
 use crate::types::{
     service_types::{DataChangeNotification, ReadValueId},

--- a/lib/src/client/subscription_state.rs
+++ b/lib/src/client/subscription_state.rs
@@ -20,13 +20,19 @@ pub struct SubscriptionState {
     subscriptions: HashMap<u32, Subscription>,
 }
 
-impl SubscriptionState {
-    pub fn new() -> SubscriptionState {
-        SubscriptionState {
+impl Default for SubscriptionState {
+    fn default() -> Self {
+        Self {
             keep_alive_timeout: None,
             last_publish_request: Instant::now(),
             subscriptions: HashMap::new(),
         }
+    }
+}
+
+impl SubscriptionState {
+    pub fn new() -> SubscriptionState {
+        SubscriptionState::default()
     }
 
     pub fn subscription_ids(&self) -> Option<Vec<u32>> {

--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -5,10 +5,11 @@
 use std::{
     io::{Cursor, Write},
     ops::Range,
-    sync::{Arc, RwLock},
+    sync::Arc,
 };
 
 use chrono::Duration;
+use parking_lot::RwLock;
 
 use crate::crypto::{
     aeskey::AesKey,
@@ -104,7 +105,7 @@ impl SecureChannel {
         decoding_options: DecodingOptions,
     ) -> SecureChannel {
         let (cert, private_key) = {
-            let certificate_store = certificate_store.read().unwrap();
+            let certificate_store = certificate_store.read();
             if let Ok((cert, pkey)) = certificate_store.read_own_cert_and_pkey() {
                 (Some(cert), Some(pkey))
             } else {

--- a/lib/src/core/comms/tcp_codec.rs
+++ b/lib/src/core/comms/tcp_codec.rs
@@ -12,9 +12,10 @@
 //! * OPN - Open Secure Channel message
 //! * CLO - Close Secure Channel message
 use std::io;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use bytes::{BufMut, BytesMut};
+use parking_lot::RwLock;
 use tokio_util::codec::{Decoder, Encoder};
 
 use crate::types::{
@@ -124,7 +125,7 @@ impl TcpCodec {
     }
 
     fn is_abort(&self) -> bool {
-        let abort = self.abort.read().unwrap();
+        let abort = self.abort.read();
         *abort
     }
 

--- a/lib/src/core/mod.rs
+++ b/lib/src/core/mod.rs
@@ -75,7 +75,7 @@ pub mod debug {
                 char_line.clear();
             }
             hex_line = format!("{} {:02x}", hex_line, value);
-            char_line.push(if value >= 32 && value <= 126 {
+            char_line.push(if (32..=126).contains(&value) {
                 value as char
             } else {
                 '.'

--- a/lib/src/core/runtime.rs
+++ b/lib/src/core/runtime.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::{
-    collections::BTreeSet,
-    sync::{Arc, Mutex},
-};
+use std::{collections::BTreeSet, sync::Arc};
+
+use parking_lot::Mutex;
 
 use crate::trace_lock;
 

--- a/lib/src/core/supported_message.rs
+++ b/lib/src/core/supported_message.rs
@@ -96,47 +96,47 @@ impl SupportedMessage {
     }
 
     pub fn is_request(&self) -> bool {
-        match self {
-            SupportedMessage::OpenSecureChannelRequest(_) => true,
-            SupportedMessage::CloseSecureChannelRequest(_) => true,
-            SupportedMessage::GetEndpointsRequest(_) => true,
-            SupportedMessage::FindServersRequest(_) => true,
-            SupportedMessage::RegisterServerRequest(_) => true,
-            SupportedMessage::RegisterServer2Request(_) => true,
-            SupportedMessage::CreateSessionRequest(_) => true,
-            SupportedMessage::CloseSessionRequest(_) => true,
-            SupportedMessage::CancelRequest(_) => true,
-            SupportedMessage::ActivateSessionRequest(_) => true,
-            SupportedMessage::AddNodesRequest(_) => true,
-            SupportedMessage::AddReferencesRequest(_) => true,
-            SupportedMessage::DeleteNodesRequest(_) => true,
-            SupportedMessage::DeleteReferencesRequest(_) => true,
-            SupportedMessage::CreateMonitoredItemsRequest(_) => true,
-            SupportedMessage::ModifyMonitoredItemsRequest(_) => true,
-            SupportedMessage::DeleteMonitoredItemsRequest(_) => true,
-            SupportedMessage::SetMonitoringModeRequest(_) => true,
-            SupportedMessage::SetTriggeringRequest(_) => true,
-            SupportedMessage::CreateSubscriptionRequest(_) => true,
-            SupportedMessage::ModifySubscriptionRequest(_) => true,
-            SupportedMessage::DeleteSubscriptionsRequest(_) => true,
-            SupportedMessage::TransferSubscriptionsRequest(_) => true,
-            SupportedMessage::SetPublishingModeRequest(_) => true,
-            SupportedMessage::QueryFirstRequest(_) => true,
-            SupportedMessage::QueryNextRequest(_) => true,
-            SupportedMessage::BrowseRequest(_) => true,
-            SupportedMessage::BrowseNextRequest(_) => true,
-            SupportedMessage::PublishRequest(_) => true,
-            SupportedMessage::RepublishRequest(_) => true,
-            SupportedMessage::TranslateBrowsePathsToNodeIdsRequest(_) => true,
-            SupportedMessage::RegisterNodesRequest(_) => true,
-            SupportedMessage::UnregisterNodesRequest(_) => true,
-            SupportedMessage::ReadRequest(_) => true,
-            SupportedMessage::HistoryReadRequest(_) => true,
-            SupportedMessage::WriteRequest(_) => true,
-            SupportedMessage::HistoryUpdateRequest(_) => true,
-            SupportedMessage::CallRequest(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            SupportedMessage::OpenSecureChannelRequest(_)
+                | SupportedMessage::CloseSecureChannelRequest(_)
+                | SupportedMessage::GetEndpointsRequest(_)
+                | SupportedMessage::FindServersRequest(_)
+                | SupportedMessage::RegisterServerRequest(_)
+                | SupportedMessage::RegisterServer2Request(_)
+                | SupportedMessage::CreateSessionRequest(_)
+                | SupportedMessage::CloseSessionRequest(_)
+                | SupportedMessage::CancelRequest(_)
+                | SupportedMessage::ActivateSessionRequest(_)
+                | SupportedMessage::AddNodesRequest(_)
+                | SupportedMessage::AddReferencesRequest(_)
+                | SupportedMessage::DeleteNodesRequest(_)
+                | SupportedMessage::DeleteReferencesRequest(_)
+                | SupportedMessage::CreateMonitoredItemsRequest(_)
+                | SupportedMessage::ModifyMonitoredItemsRequest(_)
+                | SupportedMessage::DeleteMonitoredItemsRequest(_)
+                | SupportedMessage::SetMonitoringModeRequest(_)
+                | SupportedMessage::SetTriggeringRequest(_)
+                | SupportedMessage::CreateSubscriptionRequest(_)
+                | SupportedMessage::ModifySubscriptionRequest(_)
+                | SupportedMessage::DeleteSubscriptionsRequest(_)
+                | SupportedMessage::TransferSubscriptionsRequest(_)
+                | SupportedMessage::SetPublishingModeRequest(_)
+                | SupportedMessage::QueryFirstRequest(_)
+                | SupportedMessage::QueryNextRequest(_)
+                | SupportedMessage::BrowseRequest(_)
+                | SupportedMessage::BrowseNextRequest(_)
+                | SupportedMessage::PublishRequest(_)
+                | SupportedMessage::RepublishRequest(_)
+                | SupportedMessage::TranslateBrowsePathsToNodeIdsRequest(_)
+                | SupportedMessage::RegisterNodesRequest(_)
+                | SupportedMessage::UnregisterNodesRequest(_)
+                | SupportedMessage::ReadRequest(_)
+                | SupportedMessage::HistoryReadRequest(_)
+                | SupportedMessage::WriteRequest(_)
+                | SupportedMessage::HistoryUpdateRequest(_)
+                | SupportedMessage::CallRequest(_)
+        )
     }
 
     pub fn request_header(&self) -> &RequestHeader {
@@ -184,48 +184,48 @@ impl SupportedMessage {
     }
 
     pub fn is_response(&self) -> bool {
-        match self {
-            SupportedMessage::ServiceFault(_) => true,
-            SupportedMessage::OpenSecureChannelResponse(_) => true,
-            SupportedMessage::CloseSecureChannelResponse(_) => true,
-            SupportedMessage::GetEndpointsResponse(_) => true,
-            SupportedMessage::FindServersResponse(_) => true,
-            SupportedMessage::RegisterServerResponse(_) => true,
-            SupportedMessage::RegisterServer2Response(_) => true,
-            SupportedMessage::CreateSessionResponse(_) => true,
-            SupportedMessage::CloseSessionResponse(_) => true,
-            SupportedMessage::CancelResponse(_) => true,
-            SupportedMessage::ActivateSessionResponse(_) => true,
-            SupportedMessage::AddNodesResponse(_) => true,
-            SupportedMessage::AddReferencesResponse(_) => true,
-            SupportedMessage::DeleteNodesResponse(_) => true,
-            SupportedMessage::DeleteReferencesResponse(_) => true,
-            SupportedMessage::CreateMonitoredItemsResponse(_) => true,
-            SupportedMessage::ModifyMonitoredItemsResponse(_) => true,
-            SupportedMessage::DeleteMonitoredItemsResponse(_) => true,
-            SupportedMessage::SetMonitoringModeResponse(_) => true,
-            SupportedMessage::SetTriggeringResponse(_) => true,
-            SupportedMessage::CreateSubscriptionResponse(_) => true,
-            SupportedMessage::ModifySubscriptionResponse(_) => true,
-            SupportedMessage::DeleteSubscriptionsResponse(_) => true,
-            SupportedMessage::TransferSubscriptionsResponse(_) => true,
-            SupportedMessage::SetPublishingModeResponse(_) => true,
-            SupportedMessage::QueryFirstResponse(_) => true,
-            SupportedMessage::QueryNextResponse(_) => true,
-            SupportedMessage::BrowseResponse(_) => true,
-            SupportedMessage::BrowseNextResponse(_) => true,
-            SupportedMessage::PublishResponse(_) => true,
-            SupportedMessage::RepublishResponse(_) => true,
-            SupportedMessage::TranslateBrowsePathsToNodeIdsResponse(_) => true,
-            SupportedMessage::RegisterNodesResponse(_) => true,
-            SupportedMessage::UnregisterNodesResponse(_) => true,
-            SupportedMessage::ReadResponse(_) => true,
-            SupportedMessage::HistoryReadResponse(_) => true,
-            SupportedMessage::WriteResponse(_) => true,
-            SupportedMessage::HistoryUpdateResponse(_) => true,
-            SupportedMessage::CallResponse(_) => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            SupportedMessage::ServiceFault(_)
+                | SupportedMessage::OpenSecureChannelResponse(_)
+                | SupportedMessage::CloseSecureChannelResponse(_)
+                | SupportedMessage::GetEndpointsResponse(_)
+                | SupportedMessage::FindServersResponse(_)
+                | SupportedMessage::RegisterServerResponse(_)
+                | SupportedMessage::RegisterServer2Response(_)
+                | SupportedMessage::CreateSessionResponse(_)
+                | SupportedMessage::CloseSessionResponse(_)
+                | SupportedMessage::CancelResponse(_)
+                | SupportedMessage::ActivateSessionResponse(_)
+                | SupportedMessage::AddNodesResponse(_)
+                | SupportedMessage::AddReferencesResponse(_)
+                | SupportedMessage::DeleteNodesResponse(_)
+                | SupportedMessage::DeleteReferencesResponse(_)
+                | SupportedMessage::CreateMonitoredItemsResponse(_)
+                | SupportedMessage::ModifyMonitoredItemsResponse(_)
+                | SupportedMessage::DeleteMonitoredItemsResponse(_)
+                | SupportedMessage::SetMonitoringModeResponse(_)
+                | SupportedMessage::SetTriggeringResponse(_)
+                | SupportedMessage::CreateSubscriptionResponse(_)
+                | SupportedMessage::ModifySubscriptionResponse(_)
+                | SupportedMessage::DeleteSubscriptionsResponse(_)
+                | SupportedMessage::TransferSubscriptionsResponse(_)
+                | SupportedMessage::SetPublishingModeResponse(_)
+                | SupportedMessage::QueryFirstResponse(_)
+                | SupportedMessage::QueryNextResponse(_)
+                | SupportedMessage::BrowseResponse(_)
+                | SupportedMessage::BrowseNextResponse(_)
+                | SupportedMessage::PublishResponse(_)
+                | SupportedMessage::RepublishResponse(_)
+                | SupportedMessage::TranslateBrowsePathsToNodeIdsResponse(_)
+                | SupportedMessage::RegisterNodesResponse(_)
+                | SupportedMessage::UnregisterNodesResponse(_)
+                | SupportedMessage::ReadResponse(_)
+                | SupportedMessage::HistoryReadResponse(_)
+                | SupportedMessage::WriteResponse(_)
+                | SupportedMessage::HistoryUpdateResponse(_)
+                | SupportedMessage::CallResponse(_)
+        )
     }
 
     pub fn response_header(&self) -> &ResponseHeader {

--- a/lib/src/core/tests/chunk.rs
+++ b/lib/src/core/tests/chunk.rs
@@ -53,7 +53,7 @@ fn set_chunk_sequence_number(
     sequence_number: u32,
 ) -> u32 {
     // Read the sequence header
-    let mut chunk_info = chunk.chunk_info(&secure_channel).unwrap();
+    let mut chunk_info = chunk.chunk_info(secure_channel).unwrap();
     let old_sequence_number = chunk_info.sequence_header.sequence_number;
     chunk_info.sequence_header.sequence_number = sequence_number;
     // Write the sequence header out again with new value
@@ -69,7 +69,7 @@ fn set_chunk_request_id(
     request_id: u32,
 ) -> u32 {
     // Read the sequence header
-    let mut chunk_info = chunk.chunk_info(&secure_channel).unwrap();
+    let mut chunk_info = chunk.chunk_info(secure_channel).unwrap();
     let old_request_id = chunk_info.sequence_header.request_id;
     chunk_info.sequence_header.request_id = request_id;
     // Write the sequence header out again with new value

--- a/lib/src/core/tests/mod.rs
+++ b/lib/src/core/tests/mod.rs
@@ -82,12 +82,8 @@ fn make_secure_channels(
         local_nonce.clone(),
         remote_nonce.clone(),
     );
-    let secure_channel2 = make_secure_channel(
-        security_mode,
-        security_policy,
-        remote_nonce.clone(),
-        local_nonce.clone(),
-    );
+    let secure_channel2 =
+        make_secure_channel(security_mode, security_policy, remote_nonce, local_nonce);
     (secure_channel1, secure_channel2)
 }
 

--- a/lib/src/core/tests/secure_channel.rs
+++ b/lib/src/core/tests/secure_channel.rs
@@ -24,7 +24,7 @@ fn test_symmetric_encrypt_decrypt(
 
         let mut encrypted_data = vec![0u8; chunk.data.len() + 4096];
         let encrypted_size = secure_channel1
-            .apply_security(&chunk, &mut encrypted_data[..])
+            .apply_security(chunk, &mut encrypted_data[..])
             .unwrap();
         trace!("Result of applying security = {}", encrypted_size);
 
@@ -81,7 +81,7 @@ fn test_asymmetric_encrypt_decrypt(
 
         let mut encrypted_data = vec![0u8; chunk.data.len() + 4096];
         let encrypted_size = secure_channel
-            .apply_security(&chunk, &mut encrypted_data[..])
+            .apply_security(chunk, &mut encrypted_data[..])
             .unwrap();
         trace!("Result of applying security = {}", encrypted_size);
 

--- a/lib/src/crypto/tests/crypto.rs
+++ b/lib/src/crypto/tests/crypto.rs
@@ -51,13 +51,13 @@ fn aes_test() {
     let mut plaintext2 = vec![0u8; buf_size];
 
     let plaintext2 = {
-        let r = aes_key.decrypt(&ciphertext, &iv, &mut plaintext2);
+        let r = aes_key.decrypt(ciphertext, &iv, &mut plaintext2);
         println!("result = {:?}", r);
         assert!(r.is_ok());
         &plaintext2[..r.unwrap()]
     };
 
-    assert_eq!(&plaintext[..], &plaintext2[..]);
+    assert_eq!(&plaintext[..], plaintext2);
 }
 
 #[test]
@@ -72,7 +72,7 @@ fn create_cert() {
 #[test]
 fn ensure_pki_path() {
     let (tmp_dir, cert_store) = make_certificate_store();
-    let pki = cert_store.pki_path.clone();
+    let pki = cert_store.pki_path;
     for dirname in ["rejected", "trusted"].iter() {
         let mut subdir = pki.to_path_buf();
         subdir.push(dirname);

--- a/lib/src/crypto/tests/mod.rs
+++ b/lib/src/crypto/tests/mod.rs
@@ -13,7 +13,7 @@ const APPLICATION_HOSTNAME: &str = "testhost";
 
 fn make_certificate_store() -> (TempDir, CertificateStore) {
     let tmp_dir = TempDir::new("pki").unwrap();
-    let cert_store = CertificateStore::new(&tmp_dir.path());
+    let cert_store = CertificateStore::new(tmp_dir.path());
     assert!(cert_store.ensure_pki_path().is_ok());
     (tmp_dir, cert_store)
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,8 @@
+#![allow(clippy::bool_assert_comparison)]
+#![allow(clippy::float_cmp)]
+#![allow(clippy::from_over_into)]
+#![allow(clippy::result_unit_err)]
+
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -23,7 +28,7 @@ macro_rules! trace_lock {
         {
 //            use std::thread;
 //            trace!("Thread {:?}, {} locking at {}, line {}", thread::current().id(), stringify!($x), file!(), line!());
-            let v = $x.lock().unwrap();
+            let v = $x.lock();
 //            trace!("Thread {:?}, {} lock completed", thread::current().id(), stringify!($x));
             v
         }
@@ -37,7 +42,7 @@ macro_rules! trace_read_lock {
         {
 //            use std::thread;
 //            trace!("Thread {:?}, {} read locking at {}, line {}", thread::current().id(), stringify!($x), file!(), line!());
-            let v = $x.read().unwrap();
+            let v = $x.read();
 //            trace!("Thread {:?}, {} read lock completed", thread::current().id(), stringify!($x));
             v
         }
@@ -51,7 +56,7 @@ macro_rules! trace_write_lock {
         {
 //            use std::thread;
 //            trace!("Thread {:?}, {} write locking at {}, line {}", thread::current().id(), stringify!($x), file!(), line!());
-            let v = $x.write().unwrap();
+            let v = $x.write();
 //            trace!("Thread {:?}, {} write lock completed", thread::current().id(), stringify!($x));
             v
         }

--- a/lib/src/server/address_space/method.rs
+++ b/lib/src/server/address_space/method.rs
@@ -4,7 +4,9 @@
 
 //! Contains the implementation of `Method` and `MethodBuilder`.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::types::service_types::{Argument, MethodAttributes};
 

--- a/lib/src/server/address_space/mod.rs
+++ b/lib/src/server/address_space/mod.rs
@@ -5,10 +5,9 @@
 //! Provides functionality to create an address space, find nodes, add nodes, change attributes
 //! and values on nodes.
 
-use std::{
-    result::Result,
-    sync::{Arc, Mutex},
-};
+use std::{result::Result, sync::Arc};
+
+use parking_lot::Mutex;
 
 use crate::types::status_code::StatusCode;
 use crate::types::{

--- a/lib/src/server/address_space/references.rs
+++ b/lib/src/server/address_space/references.rs
@@ -76,47 +76,39 @@ impl References {
     pub fn reference_to_node_exists(&self, node_id: &NodeId) -> bool {
         if self.referenced_by_map.contains_key(node_id) {
             debug!("Node {} is a key in references_to_map", node_id);
-            true
-        } else if self.references_map.contains_key(node_id) {
-            debug!("Node {} is a key in references_from_map", node_id);
-            true
-        } else if self
-            .references_map
-            .iter()
-            .find(|(k, v)| {
-                if let Some(r) = v.iter().find(|r| r.target_node == *node_id) {
-                    debug!(
-                        "Node {} is a value in references_from_map[{}, reference = {:?}",
-                        node_id, k, r
-                    );
-                    true
-                } else {
-                    false
-                }
-            })
-            .is_some()
-        {
-            true
-        } else if self
-            .referenced_by_map
-            .iter()
-            .find(|(k, v)| {
-                if v.contains(node_id) {
-                    debug!(
-                        "Node {} is a value in referenced_by_map, key {}",
-                        node_id, k
-                    );
-                    true
-                } else {
-                    false
-                }
-            })
-            .is_some()
-        {
-            true
-        } else {
-            false
+            return true;
         }
+        if self.references_map.contains_key(node_id) {
+            debug!("Node {} is a key in references_from_map", node_id);
+            return true;
+        }
+        if self.references_map.iter().any(|(k, v)| {
+            if let Some(r) = v.iter().find(|r| r.target_node == *node_id) {
+                debug!(
+                    "Node {} is a value in references_from_map[{}, reference = {:?}",
+                    node_id, k, r
+                );
+                true
+            } else {
+                false
+            }
+        }) {
+            return true;
+        }
+        if self.referenced_by_map.iter().any(|(k, v)| {
+            if v.contains(node_id) {
+                debug!(
+                    "Node {} is a value in referenced_by_map, key {}",
+                    node_id, k
+                );
+                true
+            } else {
+                false
+            }
+        }) {
+            return true;
+        }
+        false
     }
 
     pub fn insert_reference<T>(

--- a/lib/src/server/address_space/variable.rs
+++ b/lib/src/server/address_space/variable.rs
@@ -5,7 +5,9 @@
 //! Contains the implementation of `Variable` and `VariableBuilder`.
 
 use std::convert::{Into, TryFrom};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use crate::types::service_types::VariableAttributes;
 
@@ -463,7 +465,7 @@ impl Variable {
         use std::i32;
 
         if let Some(ref value_getter) = self.value_getter {
-            let mut value_getter = value_getter.lock().unwrap();
+            let mut value_getter = value_getter.lock();
             value_getter
                 .get(
                     &self.node_id(),
@@ -474,9 +476,10 @@ impl Variable {
                     max_age,
                 )
                 .unwrap_or_else(|status_code| {
-                    let mut value = DataValue::default();
-                    value.status = Some(status_code);
-                    Some(value)
+                    Some(DataValue {
+                        status: Some(status_code),
+                        ..Default::default()
+                    })
                 })
                 .unwrap_or_default()
         } else {
@@ -533,7 +536,7 @@ impl Variable {
 
         // The value is set to the value getter
         if let Some(ref value_setter) = self.value_setter {
-            let mut value_setter = value_setter.lock().unwrap();
+            let mut value_setter = value_setter.lock();
             value_setter.set(
                 &self.node_id(),
                 AttributeId::Value,

--- a/lib/src/server/builder.rs
+++ b/lib/src/server/builder.rs
@@ -19,15 +19,14 @@ const DEFAULT_ENDPOINT_PATH: &str = "/";
 ///
 /// [`Server`]: ../client/struct.Server.html
 /// [`ServerConfig`]: ../config/struct.ServerConfig.html
+#[derive(Default)]
 pub struct ServerBuilder {
     config: ServerConfig,
 }
 
 impl ServerBuilder {
     pub fn new() -> Self {
-        Self {
-            config: ServerConfig::default(),
-        }
+        Self::default()
     }
 
     /// Reads the config in as a starting point

--- a/lib/src/server/callbacks.rs
+++ b/lib/src/server/callbacks.rs
@@ -4,7 +4,9 @@
 
 //! Callbacks that a server implementation may register with the library
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::types::{
     service_types::{CallMethodRequest, CallMethodResult, TimestampsToReturn},

--- a/lib/src/server/comms/tcp_transport.rs
+++ b/lib/src/server/comms/tcp_transport.rs
@@ -9,14 +9,11 @@
 //! responses. i.e. the client is expected to call and wait for a response to their request.
 //! Publish requests are sent based on the number of subscriptions and the responses / handling are
 //! left to asynchronous event handlers.
-use std::{
-    collections::VecDeque,
-    net::SocketAddr,
-    sync::{Arc, Mutex, RwLock},
-};
+use std::{collections::VecDeque, net::SocketAddr, sync::Arc};
 
 use chrono::{self, Utc};
 use futures::StreamExt;
+use parking_lot::{Mutex, RwLock};
 use tokio::{
     self,
     io::AsyncWriteExt,

--- a/lib/src/server/comms/transport.rs
+++ b/lib/src/server/comms/transport.rs
@@ -6,10 +6,9 @@
 //! Provides a level of abstraction for the server to call through when it doesn't require specific
 //! knowledge of the transport it is using.
 
-use std::{
-    net::SocketAddr,
-    sync::{Arc, RwLock},
-};
+use std::{net::SocketAddr, sync::Arc};
+
+use parking_lot::RwLock;
 
 use crate::types::status_code::StatusCode;
 

--- a/lib/src/server/continuation_point.rs
+++ b/lib/src/server/continuation_point.rs
@@ -4,7 +4,9 @@
 
 //! Provides a browse continuation point type for tracking a browse operation initiated by a client.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use crate::types::{service_types::ReferenceDescription, ByteString, DateTimeUtc};
 

--- a/lib/src/server/events/audit/mod.rs
+++ b/lib/src/server/events/audit/mod.rs
@@ -8,7 +8,9 @@
 //! builder functions on each type in the hierarchy. They're not optimal at all (impls call base impls call base impls in some cases),
 //! but they should suffice for the purpose they'll be used for.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::types::*;
 

--- a/lib/src/server/events/event.rs
+++ b/lib/src/server/events/event.rs
@@ -619,7 +619,7 @@ fn test_event_time() {
         DateTime::now(),
     )
     .source_node(ObjectId::Server_ServerCapabilities);
-    let expected_time = event.time.clone();
+    let expected_time = event.time;
     assert!(event.raise(&mut address_space).is_ok());
     // Check that the helper fn returns the expected source node
     assert_eq!(
@@ -687,7 +687,7 @@ fn test_purge_events() {
 
     // Raise a bunch of events
     let start_time = DateTime::now().as_chrono();
-    let mut time = start_time.clone();
+    let mut time = start_time;
     let mut last_purged_node_id = 0;
 
     let event_type_id = ObjectTypeId::BaseEventType;

--- a/lib/src/server/events/event_filter.rs
+++ b/lib/src/server/events/event_filter.rs
@@ -195,13 +195,13 @@ fn validate_where_clause(
                 // more operands than the required #, but less is an error.
                 let operand_count_mismatch = match e.filter_operator {
                     FilterOperator::Equals => filter_operands.len() < 2,
-                    FilterOperator::IsNull => filter_operands.len() < 1,
+                    FilterOperator::IsNull => filter_operands.is_empty(),
                     FilterOperator::GreaterThan => filter_operands.len() < 2,
                     FilterOperator::LessThan => filter_operands.len() < 2,
                     FilterOperator::GreaterThanOrEqual => filter_operands.len() < 2,
                     FilterOperator::LessThanOrEqual => filter_operands.len() < 2,
                     FilterOperator::Like => filter_operands.len() < 2,
-                    FilterOperator::Not => filter_operands.len() < 1,
+                    FilterOperator::Not => filter_operands.is_empty(),
                     FilterOperator::Between => filter_operands.len() < 3,
                     FilterOperator::InList => filter_operands.len() < 2, // 2..n
                     FilterOperator::And => filter_operands.len() < 2,

--- a/lib/src/server/events/operator.rs
+++ b/lib/src/server/events/operator.rs
@@ -734,17 +734,17 @@ pub(crate) fn between(
     )? {
         ComparisonResult::GreaterThan | ComparisonResult::Equals => {
             // Element must be less than or equal to element 2
-            match compare_operands(
-                object_id,
-                &operands[0],
-                &operands[2],
-                used_elements,
-                elements,
-                address_space,
-            )? {
-                ComparisonResult::LessThan | ComparisonResult::Equals => true,
-                _ => false,
-            }
+            matches!(
+                compare_operands(
+                    object_id,
+                    &operands[0],
+                    &operands[2],
+                    used_elements,
+                    elements,
+                    address_space,
+                )?,
+                ComparisonResult::LessThan | ComparisonResult::Equals
+            )
         }
         _ => false,
     };

--- a/lib/src/server/historical/mod.rs
+++ b/lib/src/server/historical/mod.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::{
-    result::Result,
-    sync::{Arc, RwLock},
-};
+use std::{result::Result, sync::Arc};
+
+use parking_lot::RwLock;
 
 use crate::types::status_code::StatusCode;
 use crate::types::*;

--- a/lib/src/server/http/mod.rs
+++ b/lib/src/server/http/mod.rs
@@ -4,12 +4,12 @@
 
 use std::{
     path::PathBuf,
-    sync::{mpsc, Arc, RwLock},
+    sync::{mpsc, Arc},
     thread,
 };
 
 use actix_web::{actix, fs, http, server, App, HttpRequest, HttpResponse, Responder};
-
+use parking_lot::RwLock;
 use tokio::time::{interval_at, Duration, Instant};
 
 use crate::server::{metrics::ServerMetrics, server::Connections, state::ServerState};
@@ -26,7 +26,7 @@ fn abort(req: &HttpRequest<HttpState>) -> impl Responder {
     if cfg!(debug_assertions) {
         let state = req.state();
         // Abort the server from the command
-        let mut server_state = state.server_state.write().unwrap();
+        let mut server_state = state.server_state.write();
         server_state.abort();
         HttpResponse::Ok().content_type("text/plain").body("OK")
     } else {
@@ -47,17 +47,17 @@ fn metrics(req: &HttpRequest<HttpState>) -> impl Responder {
         // Careful with the ordering here to avoid potential deadlock. Metrics are locked
         // several times in scope to avoid deadlocks issues.
         {
-            let server_state = state.server_state.read().unwrap();
-            let mut server_metrics = state.server_metrics.write().unwrap();
+            let server_state = state.server_state.read();
+            let mut server_metrics = state.server_metrics.write();
             server_metrics.update_from_server_state(&server_state);
         }
 
         // Take a copy of connections
         let connections = {
-            let connections = state.connections.read().unwrap();
+            let connections = state.connections.read();
             connections.clone()
         };
-        let mut server_metrics = state.server_metrics.write().unwrap();
+        let mut server_metrics = state.server_metrics.write();
         server_metrics.update_from_connections(connections);
         serde_json::to_string_pretty(server_metrics.deref()).unwrap()
     };

--- a/lib/src/server/identity_token.rs
+++ b/lib/src/server/identity_token.rs
@@ -10,6 +10,7 @@ pub(crate) const POLICY_ID_USER_PASS_RSA_15: &str = "userpass_rsa_15";
 pub(crate) const POLICY_ID_USER_PASS_RSA_OAEP: &str = "userpass_rsa_oaep";
 pub(crate) const POLICY_ID_X509: &str = "x509";
 
+#[allow(clippy::enum_variant_names)]
 pub enum IdentityToken {
     None,
     AnonymousIdentityToken(AnonymousIdentityToken),

--- a/lib/src/server/mod.rs
+++ b/lib/src/server/mod.rs
@@ -21,10 +21,8 @@
 //!  ```no_run
 //!  use opcua::server::prelude::*;
 //!
-//!  fn main() {
-//!      let server: Server = ServerBuilder::new_sample().server().unwrap();
-//!      server.run();
-//!  }
+//!  let server: Server = ServerBuilder::new_sample().server().unwrap();
+//!  server.run();
 //!  ```
 
 /// Returns true of the Option<Vec<Foo>> is None or the vec inside is empty. This is particularly

--- a/lib/src/server/services/attribute.rs
+++ b/lib/src/server/services/attribute.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::{
-    result::Result,
-    sync::{Arc, RwLock},
-};
+use std::{result::Result, sync::Arc};
+
+use parking_lot::RwLock;
 
 use crate::{
     core::supported_message::SupportedMessage,
@@ -23,6 +22,7 @@ use crate::server::{
     state::ServerState,
 };
 
+#[allow(clippy::enum_variant_names)]
 enum ReadDetails {
     ReadEventDetails(ReadEventDetails),
     ReadRawModifiedDetails(ReadRawModifiedDetails),
@@ -30,6 +30,7 @@ enum ReadDetails {
     ReadAtTimeDetails(ReadAtTimeDetails),
 }
 
+#[allow(clippy::enum_variant_names)]
 enum UpdateDetails {
     UpdateDataDetails(UpdateDataDetails),
     UpdateStructureDataDetails(UpdateStructureDataDetails),
@@ -350,6 +351,7 @@ impl AttributeService {
         match Self::decode_history_update_details(u, decoding_options) {
             Ok(details) => {
                 let server_state = trace_read_lock!(server_state);
+
                 // Call the provider (data or event)
                 let result = match details {
                     UpdateDetails::UpdateDataDetails(details) => {
@@ -745,10 +747,7 @@ impl AttributeService {
                 match value {
                     Variant::ByteString(_) => {
                         if node_data_type == DataTypeId::Byte.into() {
-                            match value_rank {
-                                -2 | -3 | 1 => true,
-                                _ => false,
-                            }
+                            matches!(value_rank, -2 | -3 | 1)
                         } else {
                             false
                         }
@@ -837,8 +836,8 @@ impl AttributeService {
                                     err
                                 })
                         };
-                        if let Err(err) = result {
-                            err
+                        if let Err(status_code) = result {
+                            status_code
                         } else {
                             StatusCode::Good
                         }

--- a/lib/src/server/services/audit.rs
+++ b/lib/src/server/services/audit.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::types::{status_code::StatusCode, *};
 

--- a/lib/src/server/services/discovery.rs
+++ b/lib/src/server/services/discovery.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::{config::Config, supported_message::SupportedMessage};
 use crate::types::{status_code::StatusCode, *};
@@ -86,7 +88,7 @@ impl DiscoveryService {
             if !server_uris.is_empty() {
                 // Filter the servers down
                 servers
-                    .retain(|server| server_uris.iter().any(|uri| *uri == server.application_uri));
+                    .retain(|server| server_uris.iter().any(|uri| uri == &server.application_uri));
             }
         }
 

--- a/lib/src/server/services/method.rs
+++ b/lib/src/server/services/method.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::supported_message::SupportedMessage;
 use crate::types::{status_code::StatusCode, *};

--- a/lib/src/server/services/monitored_item.rs
+++ b/lib/src/server/services/monitored_item.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::supported_message::SupportedMessage;
 use crate::types::{status_code::StatusCode, *};

--- a/lib/src/server/services/node_management.rs
+++ b/lib/src/server/services/node_management.rs
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::{
-    result::Result,
-    sync::{Arc, RwLock},
-};
+use std::{result::Result, sync::Arc};
+
+use parking_lot::RwLock;
 
 use crate::core::supported_message::SupportedMessage;
 use crate::types::{node_ids::ObjectId, status_code::StatusCode, *};

--- a/lib/src/server/services/query.rs
+++ b/lib/src/server/services/query.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::supported_message::SupportedMessage;
 use crate::types::{status_code::StatusCode, *};

--- a/lib/src/server/services/session.rs
+++ b/lib/src/server/services/session.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::comms::secure_channel::SecureChannel;
 use crate::core::supported_message::SupportedMessage;

--- a/lib/src/server/services/subscription.rs
+++ b/lib/src/server/services/subscription.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::supported_message::SupportedMessage;
 use crate::types::{status_code::StatusCode, *};

--- a/lib/src/server/services/view.rs
+++ b/lib/src/server/services/view.rs
@@ -3,7 +3,9 @@
 // Copyright (C) 2017-2022 Adam Lock
 
 use std::result::Result;
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Arc;
+
+use parking_lot::{Mutex, RwLock};
 
 use crate::core::supported_message::SupportedMessage;
 use crate::crypto::random;
@@ -480,7 +482,7 @@ impl ViewService {
                 "Browsing from continuation point {}",
                 continuation_point.id.as_base64()
             );
-            let reference_descriptions = continuation_point.reference_descriptions.lock().unwrap();
+            let reference_descriptions = continuation_point.reference_descriptions.lock();
             // Use the existing result. This may result in another continuation point being created
             Self::reference_description_to_browse_result(
                 session,

--- a/lib/src/server/session.rs
+++ b/lib/src/server/session.rs
@@ -5,11 +5,12 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     sync::{
         atomic::{AtomicI32, Ordering},
-        Arc, RwLock,
+        Arc,
     },
 };
 
 use chrono::Utc;
+use parking_lot::RwLock;
 
 use crate::crypto::X509;
 use crate::types::{service_types::PublishRequest, status_code::StatusCode, *};
@@ -50,23 +51,19 @@ pub enum ServerUserIdentityToken {
     Invalid(ExtensionObject),
 }
 
+#[derive(Default)]
 pub struct SessionManager {
     pub sessions: HashMap<NodeId, Arc<RwLock<Session>>>,
     pub sessions_terminated: bool,
 }
 
-impl Default for SessionManager {
-    fn default() -> Self {
-        Self {
-            sessions: HashMap::new(),
-            sessions_terminated: false,
-        }
-    }
-}
-
 impl SessionManager {
     pub fn len(&self) -> usize {
         self.sessions.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.sessions.is_empty()
     }
 
     pub fn first(&self) -> Option<Arc<RwLock<Session>>> {

--- a/lib/src/server/session_diagnostics.rs
+++ b/lib/src/server/session_diagnostics.rs
@@ -9,20 +9,11 @@ use super::{
 
 /// This object tracks session diagnostics for exposure through the address space
 
+#[derive(Default)]
 pub(crate) struct SessionDiagnostics {
     total_request_count: u32,
     unauthorized_request_count: u32,
     service_counters: HashMap<&'static str, ServiceCounterDataType>,
-}
-
-impl Default for SessionDiagnostics {
-    fn default() -> Self {
-        Self {
-            total_request_count: 0,
-            unauthorized_request_count: 0,
-            service_counters: HashMap::new(),
-        }
-    }
 }
 
 impl SessionDiagnostics {

--- a/lib/src/server/state.rs
+++ b/lib/src/server/state.rs
@@ -4,7 +4,9 @@
 
 //! Provides server state information, such as status, configuration, running servers and so on.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::core::prelude::*;
 use crate::crypto::{user_identity, PrivateKey, SecurityPolicy, X509};

--- a/lib/src/server/subscriptions/mod.rs
+++ b/lib/src/server/subscriptions/mod.rs
@@ -26,10 +26,10 @@ pub struct PublishResponseEntry {
 }
 
 /// This converts an OPC UA Duration into a time duration used for testing for interval elapsed
-fn duration_from_ms(d: f64) -> time::Duration {
+fn duration_from_ms(d: f64) -> chrono::Duration {
     // Duration is a floating point number in millis so turn to microseconds for greater accuracy
     // 1 millisecond = 1000 microsecond
-    time::Duration::microseconds((d * 1000f64) as i64)
+    chrono::Duration::microseconds((d * 1000f64) as i64)
 }
 
 pub mod monitored_item;

--- a/lib/src/server/subscriptions/monitored_item.rs
+++ b/lib/src/server/subscriptions/monitored_item.rs
@@ -559,9 +559,9 @@ impl MonitoredItem {
 
     /// Takes the requested queue size and ensures it is within the range supported by the server
     fn sanitize_queue_size(server_state: &ServerState, requested_queue_size: usize) -> usize {
+        // For data monitored items 0 -> 1
+        // Future - for event monitored items, queue size should be the default queue size for event notifications
         if requested_queue_size == 0 || requested_queue_size == 1 {
-            // For data monitored items 0 -> 1
-            // Future - for event monitored items, queue size should be the default queue size for event notifications
             1
         // Future - for event monitored items, the minimum queue size the server requires for event notifications
         } else if requested_queue_size > server_state.max_monitored_item_queue_size {

--- a/lib/src/server/subscriptions/subscription.rs
+++ b/lib/src/server/subscriptions/subscription.rs
@@ -3,7 +3,9 @@
 // Copyright (C) 2017-2022 Adam Lock
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::types::{
     service_types::{

--- a/lib/src/server/subscriptions/subscriptions.rs
+++ b/lib/src/server/subscriptions/subscriptions.rs
@@ -312,7 +312,7 @@ impl Subscriptions {
         self.publish_request_queue.retain(|request| {
             let request_header = &request.request.request_header;
             let request_timestamp: DateTimeUtc = request_header.timestamp.into();
-            let publish_request_timeout = time::Duration::milliseconds(if request_header.timeout_hint > 0 && (request_header.timeout_hint as i64) < publish_request_timeout {
+            let publish_request_timeout = chrono::Duration::milliseconds(if request_header.timeout_hint > 0 && (request_header.timeout_hint as i64) < publish_request_timeout {
                 request_header.timeout_hint as i64
             } else {
                 publish_request_timeout

--- a/lib/src/server/tests/events.rs
+++ b/lib/src/server/tests/events.rs
@@ -127,7 +127,7 @@ fn address_space() -> AddressSpace {
     // Add attribute to event type
     let attr_foo_id = NodeId::new(ns, "Foo");
     VariableBuilder::new(&attr_foo_id, "Foo", "Foo")
-        .property_of(event_type_id.clone())
+        .property_of(event_type_id)
         .data_type(DataTypeId::UInt32)
         .has_type_definition(VariableTypeId::PropertyType)
         .has_modelling_rule(ObjectId::ModellingRule_Mandatory)
@@ -166,7 +166,7 @@ fn test_eq() {
         // Simple test, compare two values of the same kind
         let operands = &[Operand::literal(10), Operand::literal(10)];
         let result = operator::eq(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -177,7 +177,7 @@ fn test_eq() {
 
         let operands = &[Operand::literal(9), Operand::literal(10)];
         let result = operator::eq(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -188,7 +188,7 @@ fn test_eq() {
 
         let operands = &[Operand::literal(10), Operand::literal(11)];
         let result = operator::eq(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -205,7 +205,7 @@ fn test_lt() {
         // Simple test, compare two values of the same kind
         let operands = &[Operand::literal(9), Operand::literal(10)];
         let result = operator::lt(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -216,7 +216,7 @@ fn test_lt() {
 
         let operands = &[Operand::literal(10), Operand::literal(10)];
         let result = operator::lt(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -227,7 +227,7 @@ fn test_lt() {
 
         let operands = &[Operand::literal(11), Operand::literal(10)];
         let result = operator::lt(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -244,7 +244,7 @@ fn test_lte() {
         // Simple test, compare two values of the same kind
         let operands = &[Operand::literal(9), Operand::literal(10)];
         let result = operator::lte(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -255,7 +255,7 @@ fn test_lte() {
 
         let operands = &[Operand::literal(10), Operand::literal(10)];
         let result = operator::lte(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -266,7 +266,7 @@ fn test_lte() {
 
         let operands = &[Operand::literal(11), Operand::literal(10)];
         let result = operator::lte(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -283,7 +283,7 @@ fn test_gt() {
         // Simple test, compare two values of the same kind
         let operands = [Operand::literal(11), Operand::literal(10)];
         let result = operator::gt(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -294,7 +294,7 @@ fn test_gt() {
 
         let operands = &[Operand::literal(10), Operand::literal(10)];
         let result = operator::gt(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -305,7 +305,7 @@ fn test_gt() {
 
         let operands = &[Operand::literal(9), Operand::literal(10)];
         let result = operator::gt(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -322,7 +322,7 @@ fn test_gte() {
         // Simple test, compare two values of the same kind
         let operands = &[Operand::literal(11), Operand::literal(10)];
         let result = operator::gte(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -333,7 +333,7 @@ fn test_gte() {
 
         let operands = &[Operand::literal(10), Operand::literal(10)];
         let result = operator::gte(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -344,7 +344,7 @@ fn test_gte() {
 
         let operands = &[Operand::literal(9), Operand::literal(10)];
         let result = operator::gte(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -360,7 +360,7 @@ fn test_not() {
     do_operator_test(|address_space, object_id, used_elements, elements| {
         let operands = &[Operand::literal(false)];
         let result = operator::not(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -371,7 +371,7 @@ fn test_not() {
 
         let operands = &[Operand::literal(true)];
         let result = operator::not(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -383,7 +383,7 @@ fn test_not() {
         // String
         let operands = &[Operand::literal("0")];
         let result = operator::not(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -395,7 +395,7 @@ fn test_not() {
         // String(2)
         let operands = &[Operand::literal("true")];
         let result = operator::not(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -407,7 +407,7 @@ fn test_not() {
         // Invalid - Double
         let operands = &[Operand::literal(99.9)];
         let result = operator::not(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -419,7 +419,7 @@ fn test_not() {
         // Invalid - Int32
         let operands = &[Operand::literal(1)];
         let result = operator::not(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -440,7 +440,7 @@ fn test_between() {
             Operand::literal(13),
         ];
         let result = operator::between(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -455,7 +455,7 @@ fn test_between() {
             Operand::literal(13),
         ];
         let result = operator::between(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -470,7 +470,7 @@ fn test_between() {
             Operand::literal(12.4),
         ];
         let result = operator::between(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -485,7 +485,7 @@ fn test_between() {
             Operand::literal(13.0),
         ];
         let result = operator::between(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -500,7 +500,7 @@ fn test_between() {
             Operand::literal(13.0),
         ];
         let result = operator::between(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -520,7 +520,7 @@ fn test_and() {
     do_operator_test(|address_space, object_id, used_elements, elements| {
         let operands = &[Operand::literal(true), Operand::literal(true)];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -531,7 +531,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(false), Operand::literal(true)];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -542,7 +542,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(true), Operand::literal(false)];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -553,7 +553,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(false), Operand::literal(false)];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -564,7 +564,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(true), Operand::literal(())];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -575,7 +575,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(()), Operand::literal(true)];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -586,7 +586,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(false), Operand::literal(())];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -597,7 +597,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(()), Operand::literal(false)];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -608,7 +608,7 @@ fn test_and() {
 
         let operands = &[Operand::literal(()), Operand::literal(())];
         let result = operator::and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -624,7 +624,7 @@ fn test_or() {
     do_operator_test(|address_space, object_id, used_elements, elements| {
         let operands = &[Operand::literal(true), Operand::literal(true)];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -635,7 +635,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(true), Operand::literal(false)];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -646,7 +646,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(false), Operand::literal(true)];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -657,7 +657,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(false), Operand::literal(false)];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -668,7 +668,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(true), Operand::literal(())];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -679,7 +679,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(()), Operand::literal(true)];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -690,7 +690,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(false), Operand::literal(())];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -701,7 +701,7 @@ fn test_or() {
 
         let operands = &[Operand::literal(()), Operand::literal(false)];
         let result = operator::or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -717,7 +717,7 @@ fn test_in_list() {
     do_operator_test(|address_space, object_id, used_elements, elements| {
         let operands = &[Operand::literal(10), Operand::literal(false)];
         let result = operator::in_list(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -728,7 +728,7 @@ fn test_in_list() {
 
         let operands = &[Operand::literal(true), Operand::literal(false)];
         let result = operator::in_list(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -761,7 +761,7 @@ fn test_bitwise_or() {
     do_operator_test(|address_space, object_id, used_elements, elements| {
         let operands = &[Operand::literal(0xff00u16), Operand::literal(0x00ffu16)];
         let result = operator::bitwise_or(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,
@@ -777,7 +777,7 @@ fn test_bitwise_and() {
     do_operator_test(|address_space, object_id, used_elements, elements| {
         let operands = &[Operand::literal(0xf00fu16), Operand::literal(0x00ffu16)];
         let result = operator::bitwise_and(
-            &object_id,
+            object_id,
             &operands[..],
             used_elements,
             elements,

--- a/lib/src/server/tests/mod.rs
+++ b/lib/src/server/tests/mod.rs
@@ -1,10 +1,6 @@
-use std::{
-    path::PathBuf,
-    sync::{Arc, RwLock},
-};
+use std::{path::PathBuf, sync::Arc};
 
-use chrono;
-use time;
+use parking_lot::RwLock;
 
 use crate::core::{config::Config, supported_message::SupportedMessage};
 use crate::types::{status_code::StatusCode, *};
@@ -105,11 +101,11 @@ pub fn server_config_invalid() {
 #[test]
 pub fn expired_publish_requests() {
     let now = chrono::Utc::now();
-    let now_plus_5s = now + time::Duration::seconds(5);
+    let now_plus_5s = now + chrono::Duration::seconds(5);
 
     // Create two publish requests timestamped now, one which expires in > 30s, one which expires
     // in > 20s
-    let now = DateTime::from(now.clone());
+    let now = DateTime::from(now);
     let mut pr1 = PublishRequestEntry {
         request_id: 1,
         request: PublishRequest {

--- a/lib/src/server/tests/services/discovery.rs
+++ b/lib/src/server/tests/services/discovery.rs
@@ -108,11 +108,11 @@ fn discovery_test() {
             )];
             let request = GetEndpointsRequest {
                 request_header: make_request_header(),
-                endpoint_url: endpoint_url.clone(),
+                endpoint_url,
                 locale_ids: None,
                 profile_uris: Some(profile_uris),
             };
-            let result = ds.get_endpoints(server_state.clone(), &request);
+            let result = ds.get_endpoints(server_state, &request);
             let result = supported_message_as!(result, GetEndpointsResponse);
             let endpoints = result.endpoints.unwrap();
             assert!(!endpoints.is_empty())

--- a/lib/src/server/tests/services/method.rs
+++ b/lib/src/server/tests/services/method.rs
@@ -27,7 +27,7 @@ where
 
     let (server_state, session) = st.get_server_state_and_session();
     let address_space = st.address_space.clone();
-    let session_manager = st.session_manager.clone();
+    let session_manager = st.session_manager;
     f(server_state, session_manager, session, address_space, &s);
 }
 
@@ -288,10 +288,10 @@ fn call_getmonitoreditems() {
             );
             let response = call_single(
                 s,
-                server_state.clone(),
-                session_manager.clone(),
-                session.clone(),
-                address_space.clone(),
+                server_state,
+                session_manager,
+                session,
+                address_space,
                 request,
             )
             .unwrap();
@@ -307,7 +307,7 @@ fn call_getmonitoreditems() {
                 assert_eq!(values.len(), 1);
                 assert_eq!(Variant::from(monitored_item_id), values.pop().unwrap());
             } else {
-                assert!(false);
+                panic!();
             }
 
             if let Variant::Array(array) = client_handles {
@@ -315,7 +315,7 @@ fn call_getmonitoreditems() {
                 assert_eq!(values.len(), 1);
                 assert_eq!(Variant::from(999u32), values.pop().unwrap());
             } else {
-                assert!(false);
+                panic!();
             }
         }
     });
@@ -378,10 +378,10 @@ fn call_resend_data() {
                 new_call_method_request(ObjectId::Server, MethodId::Server_ResendData, Some(args));
             let response = call_single(
                 s,
-                server_state.clone(),
-                session_manager.clone(),
-                session.clone(),
-                address_space.clone(),
+                server_state,
+                session_manager,
+                session,
+                address_space,
                 request,
             )
             .unwrap();

--- a/lib/src/server/tests/services/mod.rs
+++ b/lib/src/server/tests/services/mod.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::server::{
     prelude::*,
@@ -108,7 +110,7 @@ where
     f(
         st.server_state.clone(),
         st.session.clone(),
-        st.address_space.clone(),
+        st.address_space,
         SubscriptionService::new(),
         MonitoredItemService::new(),
     );

--- a/lib/src/server/tests/services/node_management.rs
+++ b/lib/src/server/tests/services/node_management.rs
@@ -29,7 +29,7 @@ where
     f(
         st.server_state.clone(),
         st.session.clone(),
-        st.address_space.clone(),
+        st.address_space,
         NodeManagementService::new(),
     );
 }
@@ -257,9 +257,9 @@ fn add_nodes_nothing_to_do() {
             );
 
             let response = nms.add_nodes(
-                server_state.clone(),
-                session.clone(),
-                address_space.clone(),
+                server_state,
+                session,
+                address_space,
                 &AddNodesRequest {
                     request_header: RequestHeader::dummy(),
                     nodes_to_add: Some(vec![]),

--- a/lib/src/server/tests/services/session.rs
+++ b/lib/src/server/tests/services/session.rs
@@ -43,13 +43,13 @@ where
     };
 
     let st = ServiceTest::new_with_server(server_builder);
-    f(st.server_state.clone(), SessionService::new());
+    f(st.server_state, SessionService::new());
 }
 
 #[test]
 fn anonymous_user_token() {
-    do_session_service_test(None, |server_state, session_service| {
-        let server_state = server_state.read().unwrap();
+    do_session_service_test(None, |server_state, _session_service| {
+        let server_state = server_state.read();
 
         // Makes an anonymous token and sticks it into an extension object
         let token = AnonymousIdentityToken {
@@ -146,10 +146,10 @@ fn make_unencrypted_user_name_identity_token(user: &str, pass: &str) -> Extensio
 fn user_name_pass_token() {
     do_session_service_test(
         Some("./pki_user_name_pass_token"),
-        |server_state, session_service| {
+        |server_state, _session_service| {
             let server_nonce = random::byte_string(20);
 
-            let server_state = server_state.read().unwrap();
+            let server_state = server_state.read();
             let server_cert = server_state.server_certificate.clone();
             assert!(server_cert.is_some());
 

--- a/lib/src/server/tests/subscriptions/subscription.rs
+++ b/lib/src/server/tests/subscriptions/subscription.rs
@@ -1,4 +1,6 @@
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::server::{
     diagnostics::ServerDiagnostics,

--- a/lib/src/server/util/mod.rs
+++ b/lib/src/server/util/mod.rs
@@ -4,7 +4,9 @@
 
 //! Provides utility routines for things that might be used in a number of places elsewhere.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use tokio::time::{interval_at, Duration, Instant};
 

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -121,10 +121,10 @@ impl From<(u16, u16, u16, u16, u16, u16)> for DateTime {
 impl From<(u16, u16, u16, u16, u16, u16, u32)> for DateTime {
     fn from(dt: (u16, u16, u16, u16, u16, u16, u32)) -> Self {
         let (year, month, day, hour, minute, second, nanos) = dt;
-        if month < 1 || month > 12 {
+        if !(1..=12).contains(&month) {
             panic!("Invalid month");
         }
-        if day < 1 || day > 31 {
+        if !(1..=31).contains(&day) {
             panic!("Invalid day");
         }
         if hour > 23 {

--- a/lib/src/types/service_types/impls.rs
+++ b/lib/src/types/service_types/impls.rs
@@ -17,8 +17,8 @@ use crate::types::{
         enums::DeadbandType, AnonymousIdentityToken, ApplicationDescription, ApplicationType,
         Argument, CallMethodRequest, DataChangeFilter, DataChangeTrigger, EndpointDescription,
         MessageSecurityMode, MonitoredItemCreateRequest, MonitoringMode, MonitoringParameters,
-        ReadValueId, ServerDiagnosticsSummaryDataType, ServiceCounterDataType, ServiceFault,
-        SignatureData, UserNameIdentityToken, UserTokenPolicy, UserTokenType,
+        ReadValueId, ServiceCounterDataType, ServiceFault, SignatureData, UserNameIdentityToken,
+        UserTokenPolicy, UserTokenType,
     },
     status_codes::StatusCode,
     string::UAString,
@@ -343,25 +343,6 @@ impl Into<CallMethodRequest> for (NodeId, NodeId, Option<Vec<Variant>>) {
     }
 }
 
-impl Default for ServerDiagnosticsSummaryDataType {
-    fn default() -> Self {
-        ServerDiagnosticsSummaryDataType {
-            server_view_count: 0,
-            current_session_count: 0,
-            cumulated_session_count: 0,
-            security_rejected_session_count: 0,
-            rejected_session_count: 0,
-            session_timeout_count: 0,
-            session_abort_count: 0,
-            current_subscription_count: 0,
-            cumulated_subscription_count: 0,
-            publishing_interval_count: 0,
-            security_rejected_requests_count: 0,
-            rejected_requests_count: 0,
-        }
-    }
-}
-
 impl<'a> From<&'a str> for EndpointDescription {
     fn from(v: &'a str) -> Self {
         EndpointDescription::from((
@@ -470,15 +451,6 @@ impl From<(&str, DataTypeId)> for Argument {
             value_rank: -1,
             array_dimensions: None,
             description: LocalizedText::new("", ""),
-        }
-    }
-}
-
-impl Default for ServiceCounterDataType {
-    fn default() -> Self {
-        Self {
-            total_count: 0,
-            error_count: 0,
         }
     }
 }

--- a/lib/src/types/service_types/server_diagnostics_summary_data_type.rs
+++ b/lib/src/types/service_types/server_diagnostics_summary_data_type.rs
@@ -15,7 +15,7 @@ use crate::types::{
     node_ids::ObjectId,
 };
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
 pub struct ServerDiagnosticsSummaryDataType {
     pub server_view_count: u32,
     pub current_session_count: u32,

--- a/lib/src/types/service_types/service_counter_data_type.rs
+++ b/lib/src/types/service_types/service_counter_data_type.rs
@@ -15,7 +15,7 @@ use crate::types::{
     node_ids::ObjectId,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct ServiceCounterDataType {
     pub total_count: u32,
     pub error_count: u32,

--- a/lib/src/types/tests/encoding.rs
+++ b/lib/src/types/tests/encoding.rs
@@ -10,72 +10,72 @@ fn encoding_bool() {
 
 #[test]
 fn encoding_sbyte() {
-    serialize_test(0 as i8);
-    serialize_test(100 as i8);
-    serialize_test(-90 as i8);
+    serialize_test(0_i8);
+    serialize_test(100_i8);
+    serialize_test(-90_i8);
 }
 
 #[test]
 fn encoding_byte() {
-    serialize_test(0 as u8);
-    serialize_test(255 as u8);
-    serialize_test(90 as u8);
+    serialize_test(0_u8);
+    serialize_test(255_u8);
+    serialize_test(90_u8);
 }
 
 #[test]
 fn encoding_int16() {
-    serialize_test(0 as i16);
-    serialize_test(-17000 as i16);
-    serialize_test(32000 as i16);
+    serialize_test(0_i16);
+    serialize_test(-17000_i16);
+    serialize_test(32000_i16);
 }
 
 #[test]
 fn encoding_uint16() {
-    serialize_test(0 as u16);
-    serialize_test(57000 as u16);
-    serialize_test(32000 as u16);
+    serialize_test(0_u16);
+    serialize_test(57000_u16);
+    serialize_test(32000_u16);
 }
 
 #[test]
 fn encoding_int32() {
-    serialize_test(0 as i32);
-    serialize_test(-17444000 as i32);
-    serialize_test(32004440 as i32);
+    serialize_test(0_i32);
+    serialize_test(-17444000_i32);
+    serialize_test(32004440_i32);
 }
 
 #[test]
 fn encoding_uint32() {
-    serialize_test(0 as u32);
-    serialize_test(57055500 as u32);
-    serialize_test(32555000 as u32);
+    serialize_test(0_u32);
+    serialize_test(57055500_u32);
+    serialize_test(32555000_u32);
 }
 
 #[test]
 fn encoding_int64() {
-    serialize_test(0 as i64);
-    serialize_test(-17442224000 as i64);
-    serialize_test(32022204440 as i64);
+    serialize_test(0_i64);
+    serialize_test(-17442224000_i64);
+    serialize_test(32022204440_i64);
 }
 
 #[test]
 fn encoding_uint64() {
-    serialize_test(0 as u64);
-    serialize_test(57054445500 as u64);
-    serialize_test(34442555000 as u64);
+    serialize_test(0_u64);
+    serialize_test(57054445500_u64);
+    serialize_test(34442555000_u64);
 }
 
 #[test]
 fn encoding_f32() {
-    serialize_test(0 as f32);
-    serialize_test(12.4342 as f32);
-    serialize_test(5686.222 as f32);
+    serialize_test(0_f32);
+    serialize_test(12.4342_f32);
+    serialize_test(5686.222_f32);
 }
 
 #[test]
 fn encoding_f64() {
-    serialize_test(0 as f64);
-    serialize_test(12.43424324234 as f64);
-    serialize_test(5686.222342342 as f64);
+    serialize_test(0_f64);
+    serialize_test(12.43424324234_f64);
+    serialize_test(5686.222342342_f64);
 }
 
 #[test]
@@ -158,7 +158,7 @@ fn encode_guid_5226() {
 #[test]
 fn node_id_2byte_numeric() {
     // Sample from OPCUA Part 6 - 5.2.2.9
-    let node_id = NodeId::new(0, 0x72 as u32);
+    let node_id = NodeId::new(0, 0x72_u32);
     let expected_bytes = [0x0, 0x72];
     serialize_and_compare(node_id.clone(), &expected_bytes);
 
@@ -192,7 +192,7 @@ fn node_id_large_namespace() {
 
 #[test]
 fn node_id_large_id() {
-    let node_id = NodeId::new(1, 0xdeadbeef as u32);
+    let node_id = NodeId::new(1, 0xdeadbeef_u32);
     assert!(node_id.is_numeric());
 
     let expected_bytes = [0x2, 0x1, 0x0, 0xef, 0xbe, 0xad, 0xde];
@@ -492,7 +492,7 @@ fn diagnostic_info() {
         inner_diagnostic_info: None,
     }));
 
-    serialize_test(d.clone());
+    serialize_test(d);
 }
 
 #[test]

--- a/samples/chess-server/Cargo.toml
+++ b/samples/chess-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+parking_lot = { version = "0.12", features = ["send_guard"] }
 uci = "0.1.1"
 
 [dependencies.opcua]

--- a/samples/chess-server/src/main.rs
+++ b/samples/chess-server/src/main.rs
@@ -4,10 +4,11 @@
 
 use std::env;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread;
 
 use opcua::server::prelude::*;
+use parking_lot::Mutex;
 
 mod game;
 
@@ -45,7 +46,7 @@ fn main() {
     let address_space = server.address_space();
 
     let ns = {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
 
         let ns = address_space
             .register_namespace("urn:chess-server")
@@ -75,7 +76,7 @@ fn main() {
                 .insert(&mut address_space);
         });
 
-        let game = game.lock().unwrap();
+        let game = game.lock();
         update_board_state(&game, &mut address_space, ns);
 
         ns
@@ -90,7 +91,7 @@ fn main() {
         use std::time::Duration;
 
         let sleep_time = Duration::from_millis(1500);
-        let mut game = game.lock().unwrap();
+        let mut game = game.lock();
         loop {
             game.set_position();
             let bestmove = game.bestmove().unwrap();
@@ -114,7 +115,7 @@ fn main() {
                 game.print_board();
 
                 {
-                    let mut address_space = address_space.write().unwrap();
+                    let mut address_space = address_space.write();
                     update_board_state(&game, &mut address_space, ns);
                 }
             }

--- a/samples/demo-server/Cargo.toml
+++ b/samples/demo-server/Cargo.toml
@@ -9,11 +9,12 @@ vendored-openssl = ["opcua/vendored-openssl"]
 
 [dependencies]
 chrono = "0.4"
-log = "0.4"
-rand = "0.7"
-log4rs = "0.8"
 lazy_static = "1.4.0"
+log = "0.4"
+log4rs = "0.8"
+parking_lot = { version = "0.12", features = ["send_guard"] }
 pico-args = "0.3"
+rand = "0.7"
 
 [dependencies.opcua]
 path = "../../lib"

--- a/samples/demo-server/src/control.rs
+++ b/samples/demo-server/src/control.rs
@@ -12,7 +12,7 @@ pub fn add_control_switches(server: &mut Server, ns: u16) {
     let server_state = server.server_state();
 
     {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         let folder_id = address_space
             .add_folder("Control", "Control", &NodeId::objects_folder_id())
             .unwrap();
@@ -26,7 +26,7 @@ pub fn add_control_switches(server: &mut Server, ns: u16) {
     }
 
     server.add_polling_action(1000, move || {
-        let address_space = address_space.read().unwrap();
+        let address_space = address_space.read();
         // Test for abort flag
         let abort = if let Ok(v) = address_space.get_variable_value(abort_node_id.clone()) {
             match v.value {
@@ -40,7 +40,7 @@ pub fn add_control_switches(server: &mut Server, ns: u16) {
         };
         // Check if abort has been set to true, in which case abort
         if abort {
-            let mut server_state = server_state.write().unwrap();
+            let mut server_state = server_state.write();
             server_state.abort();
         }
     });

--- a/samples/demo-server/src/historical.rs
+++ b/samples/demo-server/src/historical.rs
@@ -3,14 +3,16 @@
 // Copyright (C) 2017-2022 Adam Lock
 
 //! Implementations of HistoricalDataProvider and HistoricalEventProvider
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use opcua::server::prelude::*;
 
 // Register some historical data providers
 pub fn add_providers(server: &mut Server) {
     let server_state = server.server_state();
-    let mut server_state = server_state.write().unwrap();
+    let mut server_state = server_state.write();
     server_state.set_historical_data_provider(Box::new(DataProvider));
     server_state.set_historical_event_provider(Box::new(EventProvider));
 }

--- a/samples/demo-server/src/machine.rs
+++ b/samples/demo-server/src/machine.rs
@@ -18,7 +18,7 @@ pub fn add_machinery(server: &mut Server, ns: u16, raise_event: bool) {
     let machine2_counter = Arc::new(AtomicU16::new(50));
 
     let (machine1_id, machine2_id) = {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         add_machinery_model(&mut address_space, ns);
 
         // Create a folder under static folder
@@ -54,7 +54,7 @@ pub fn add_machinery(server: &mut Server, ns: u16, raise_event: bool) {
 
     // Increment counters
     server.add_polling_action(300, move || {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         increment_counter(
             &mut address_space,
             ns,

--- a/samples/demo-server/src/main.rs
+++ b/samples/demo-server/src/main.rs
@@ -75,7 +75,7 @@ fn main() {
 
         let ns = {
             let address_space = server.address_space();
-            let mut address_space = address_space.write().unwrap();
+            let mut address_space = address_space.write();
             address_space.register_namespace("urn:demo-server").unwrap()
         };
 

--- a/samples/demo-server/src/methods.rs
+++ b/samples/demo-server/src/methods.rs
@@ -4,7 +4,9 @@
 
 //! A sample method
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use opcua::server::{
     address_space::method::MethodBuilder, callbacks, prelude::*, session::SessionManager,
@@ -12,7 +14,7 @@ use opcua::server::{
 
 pub fn add_methods(server: &mut Server, ns: u16) {
     let address_space = server.address_space();
-    let mut address_space = address_space.write().unwrap();
+    let mut address_space = address_space.write();
 
     let object_id = NodeId::new(ns, "Functions");
     ObjectBuilder::new(&object_id, "Functions", "Functions")

--- a/samples/demo-server/src/scalar.rs
+++ b/samples/demo-server/src/scalar.rs
@@ -10,7 +10,7 @@ use opcua::server::prelude::*;
 pub fn add_scalar_variables(server: &mut Server, ns: u16) {
     let (static_folder_id, dynamic_folder_id) = {
         let address_space = server.address_space();
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         (
             address_space
                 .add_folder("Static", "Static", &NodeId::objects_folder_id())
@@ -170,7 +170,7 @@ pub fn scalar_random_value(id: DataTypeId) -> Variant {
 fn add_static_scalar_variables(server: &mut Server, ns: u16, static_folder_id: &NodeId) {
     // The address space is guarded so obtain a lock to change it
     let address_space = server.address_space();
-    let mut address_space = address_space.write().unwrap();
+    let mut address_space = address_space.write();
 
     // Create a folder under static folder
     let folder_id = address_space
@@ -192,7 +192,7 @@ fn add_static_scalar_variables(server: &mut Server, ns: u16, static_folder_id: &
 fn add_static_array_variables(server: &mut Server, ns: u16, static_folder_id: &NodeId) {
     // The address space is guarded so obtain a lock to change it
     let address_space = server.address_space();
-    let mut address_space = address_space.write().unwrap();
+    let mut address_space = address_space.write();
 
     // Create a folder under static folder
     let folder_id = address_space
@@ -220,7 +220,7 @@ fn add_static_array_variables(server: &mut Server, ns: u16, static_folder_id: &N
 fn add_dynamic_scalar_variables(server: &mut Server, ns: u16, dynamic_folder_id: &NodeId) {
     // The address space is guarded so obtain a lock to change it
     let address_space = server.address_space();
-    let mut address_space = address_space.write().unwrap();
+    let mut address_space = address_space.write();
 
     // Create a folder under static folder
     let folder_id = address_space
@@ -241,7 +241,7 @@ fn add_dynamic_scalar_variables(server: &mut Server, ns: u16, dynamic_folder_id:
 fn add_dynamic_array_variables(server: &mut Server, ns: u16, dynamic_folder_id: &NodeId) {
     // The address space is guarded so obtain a lock to change it
     let address_space = server.address_space();
-    let mut address_space = address_space.write().unwrap();
+    let mut address_space = address_space.write();
 
     // Create a folder under static folder
     let folder_id = address_space
@@ -269,7 +269,7 @@ fn set_dynamic_timers(server: &mut Server, ns: u16) {
 
     // Standard change timers
     server.add_polling_action(250, move || {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         // Scalar
         let now = DateTime::now();
         SCALAR_TYPES.iter().for_each(|sn| {
@@ -298,7 +298,7 @@ pub fn add_stress_variables(server: &mut Server, ns: u16) {
         .collect::<Vec<NodeId>>();
 
     let address_space = server.address_space();
-    let mut address_space = address_space.write().unwrap();
+    let mut address_space = address_space.write();
 
     let folder_id = address_space
         .add_folder("Stress", "Stress", &NodeId::objects_folder_id())
@@ -320,7 +320,7 @@ fn set_stress_timer(server: &mut Server, node_ids: Vec<NodeId>) {
     let address_space = server.address_space();
     server.add_polling_action(100, move || {
         let mut rng = rand::thread_rng();
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         let now = DateTime::now();
         node_ids.iter().for_each(|node_id| {
             let value: Variant = rng.gen::<i32>().into();

--- a/samples/event-client/Cargo.toml
+++ b/samples/event-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+parking_lot = { version = "0.12", features = ["send_guard"] }
 pico-args="0.3"
 
 [dependencies.opcua]

--- a/samples/event-client/src/main.rs
+++ b/samples/event-client/src/main.rs
@@ -8,7 +8,9 @@
 //! 2. Connect to an endpoint specified by the url with security None
 //! 3. Subscribe to values and loop forever printing out their values
 use std::str::FromStr;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use opcua::client::prelude::*;
 
@@ -103,7 +105,7 @@ fn subscribe_to_events(
     event_source: &str,
     event_fields: &str,
 ) -> Result<(), StatusCode> {
-    let session = session.read().unwrap();
+    let session = session.read();
 
     let event_fields: Vec<String> = event_fields.split(',').map(|s| s.into()).collect();
 

--- a/samples/modbus-server/Cargo.toml
+++ b/samples/modbus-server/Cargo.toml
@@ -5,16 +5,17 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-pico-args = "0.3"
-tokio = "0.1"
-tokio-core = "0.1"
-tokio-service = "0.1"
-tokio-timer = "0.2"
-tokio-modbus = { version = "0.3.5", default-features = false, features = ["tcp"] }
 futures = "0.1"
+parking_lot = { version = "0.12", features = ["send_guard"] }
+pico-args = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8"
+tokio = "0.1"
+tokio-core = "0.1"
+tokio-modbus = { version = "0.3.5", default-features = false, features = ["tcp"] }
+tokio-service = "0.1"
+tokio-timer = "0.2"
 
 [dependencies.opcua]
 path = "../../lib"

--- a/samples/modbus-server/src/main.rs
+++ b/samples/modbus-server/src/main.rs
@@ -10,11 +10,9 @@
 #[macro_use]
 extern crate serde_derive;
 
-use std::{
-    path::PathBuf,
-    sync::{Arc, RwLock},
-    thread,
-};
+use std::{path::PathBuf, sync::Arc, thread};
+
+use parking_lot::RwLock;
 
 use ::opcua::console_logging;
 

--- a/samples/modbus-server/src/master.rs
+++ b/samples/modbus-server/src/master.rs
@@ -3,12 +3,13 @@
 // Copyright (C) 2017-2022 Adam Lock
 
 use std::{
-    sync::{Arc, RwLock},
+    sync::Arc,
     thread,
     time::{Duration, Instant},
 };
 
 use futures::{sink::Sink, stream::Stream, Future};
+use parking_lot::RwLock;
 use tokio::sync as tsync;
 use tokio_core::reactor::Core;
 use tokio_modbus::{client, prelude::*};
@@ -26,7 +27,7 @@ pub struct MODBUS {
 impl MODBUS {
     pub fn run(runtime: Arc<RwLock<Runtime>>) -> MODBUS {
         let socket_addr = {
-            let runtime = runtime.read().unwrap();
+            let runtime = runtime.read();
             runtime.config.slave_address.parse().unwrap()
         };
 
@@ -94,13 +95,13 @@ impl MODBUS {
 }
 
 fn store_values_in_coils(values: Vec<bool>, coils: Arc<RwLock<Vec<bool>>>) {
-    let mut coils = coils.write().unwrap();
+    let mut coils = coils.write();
     coils.clear();
     coils.extend(values);
 }
 
 fn store_values_in_registers(values: Vec<u16>, registers: Arc<RwLock<Vec<u16>>>) {
-    let mut registers = registers.write().unwrap();
+    let mut registers = registers.write();
     registers.clear();
     registers.extend(values);
 }
@@ -133,7 +134,7 @@ impl InputCoil {
     fn begin_read_input_coils(
         runtime: &Arc<RwLock<Runtime>>,
     ) -> (Arc<RwLock<Vec<bool>>>, u16, u16) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_input_coils = true;
         (
             runtime.input_coils.clone(),
@@ -143,7 +144,7 @@ impl InputCoil {
     }
 
     fn end_read_input_coils(runtime: &Arc<RwLock<Runtime>>) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_input_coils = false;
     }
 }
@@ -185,7 +186,7 @@ impl OutputCoil {
     fn begin_read_output_coils(
         runtime: &Arc<RwLock<Runtime>>,
     ) -> (Arc<RwLock<Vec<bool>>>, u16, u16) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_output_coils = true;
         (
             runtime.output_coils.clone(),
@@ -195,7 +196,7 @@ impl OutputCoil {
     }
 
     fn end_read_output_coils(runtime: &Arc<RwLock<Runtime>>) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_output_coils = false;
     }
 }
@@ -228,7 +229,7 @@ impl InputRegister {
     fn begin_read_input_registers(
         runtime: &Arc<RwLock<Runtime>>,
     ) -> (Arc<RwLock<Vec<u16>>>, u16, u16) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_input_registers = true;
         (
             runtime.input_registers.clone(),
@@ -238,7 +239,7 @@ impl InputRegister {
     }
 
     fn end_read_input_registers(runtime: &Arc<RwLock<Runtime>>) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_input_registers = false;
     }
 }
@@ -289,7 +290,7 @@ impl OutputRegister {
     fn begin_read_output_registers(
         runtime: &Arc<RwLock<Runtime>>,
     ) -> (Arc<RwLock<Vec<u16>>>, u16, u16) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_input_registers = true;
         (
             runtime.output_registers.clone(),
@@ -299,7 +300,7 @@ impl OutputRegister {
     }
 
     fn end_read_output_registers(runtime: &Arc<RwLock<Runtime>>) {
-        let mut runtime = runtime.write().unwrap();
+        let mut runtime = runtime.write();
         runtime.reading_output_registers = false;
     }
 }
@@ -329,7 +330,7 @@ fn spawn_receiver(
                         read_input_coils,
                         read_output_coils,
                     ) = {
-                        let runtime = runtime.read().unwrap();
+                        let runtime = runtime.read();
                         (
                             !runtime.reading_input_registers
                                 && runtime.config.input_registers.readable(),
@@ -353,19 +354,19 @@ fn spawn_receiver(
                     }
                 }
                 Message::WriteCoil(addr, value) => {
-                    let runtime = runtime.read().unwrap();
+                    let runtime = runtime.read();
                     if runtime.config.output_coils.writable() {
                         OutputCoil::async_write(&handle_for_action, &ctx, addr, value);
                     }
                 }
                 Message::WriteRegister(addr, value) => {
-                    let runtime = runtime.read().unwrap();
+                    let runtime = runtime.read();
                     if runtime.config.output_registers.writable() {
                         OutputRegister::async_write_register(&handle_for_action, &ctx, addr, value);
                     }
                 }
                 Message::WriteRegisters(addr, values) => {
-                    let runtime = runtime.read().unwrap();
+                    let runtime = runtime.read();
                     if runtime.config.output_registers.writable() {
                         OutputRegister::async_write_registers(
                             &handle_for_action,
@@ -389,7 +390,7 @@ fn spawn_timer(
     runtime: Arc<RwLock<Runtime>>,
 ) -> impl Future<Error = ()> {
     let interval = {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         Duration::from_millis(runtime.config.read_interval as u64)
     };
     let handle = handle.clone();

--- a/samples/modbus-server/src/opcua.rs
+++ b/samples/modbus-server/src/opcua.rs
@@ -2,14 +2,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2017-2022 Adam Lock
 
-use std::{
-    f32, f64, i16, i32, i64, i8,
-    path::PathBuf,
-    sync::{Arc, Mutex, RwLock},
-    u16,
-};
+use std::{f32, f64, i16, i32, i64, i8, path::PathBuf, sync::Arc, u16};
 
 use opcua::server::prelude::*;
+use parking_lot::{Mutex, RwLock};
 
 use crate::{
     config::{Alias, AliasType, TableConfig},
@@ -27,7 +23,7 @@ pub fn run(runtime: Arc<RwLock<Runtime>>, modbus: MODBUS) {
     let modbus = Arc::new(Mutex::new(modbus));
 
     {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         let nsidx = address_space.register_namespace("urn:MODBUS").unwrap();
         add_variables(runtime, modbus, &mut address_space, nsidx);
     }
@@ -89,7 +85,7 @@ fn add_input_coils(
         .unwrap();
 
     let (start, end, values) = {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         let (start, end) = start_end(&runtime.config.input_coils);
         let values = runtime.input_coils.clone();
         (start, end, values)
@@ -121,7 +117,7 @@ fn add_output_coils(
         .unwrap();
 
     let (start, end, values) = {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         let (start, end) = start_end(&runtime.config.output_coils);
         let values = runtime.output_coils.clone();
         (start, end, values)
@@ -153,7 +149,7 @@ fn add_input_registers(
         .unwrap();
     // Add variables to the folder
     let (start, end, values) = {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         let (start, end) = start_end(&runtime.config.input_registers);
         let values = runtime.input_registers.clone();
         (start, end, values)
@@ -184,7 +180,7 @@ fn add_output_registers(
         .unwrap();
     // Add variables to the folder
     let (start, end, values) = {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         let (start, end) = start_end(&runtime.config.output_registers);
         let values = runtime.output_registers.clone();
         (start, end, values)
@@ -211,7 +207,7 @@ fn add_aliases(
     parent_folder_id: &NodeId,
 ) {
     let aliases = {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         runtime.config.aliases.clone()
     };
     if let Some(aliases) = aliases {
@@ -278,7 +274,7 @@ fn make_variables<T>(
                       _name,
                       _f|
                       -> Result<Option<DataValue>, StatusCode> {
-                    let values = values.read().unwrap();
+                    let values = values.read();
                     let value = *values.get(i - start).unwrap();
                     Ok(Some(DataValue::new_now(value)))
                 },
@@ -299,7 +295,7 @@ fn make_variables<T>(
                                 Variant::Empty
                             };
                             if let Variant::Boolean(value) = value {
-                                let modbus = modbus.lock().unwrap();
+                                let modbus = modbus.lock();
                                 modbus.write_to_coil(addr, value);
                                 Ok(())
                             } else {
@@ -321,7 +317,7 @@ fn make_variables<T>(
                                 Variant::Empty
                             };
                             if let Variant::UInt16(value) = value {
-                                let modbus = modbus.lock().unwrap();
+                                let modbus = modbus.lock();
                                 modbus.write_to_register(addr, value);
                                 Ok(())
                             } else {
@@ -412,7 +408,7 @@ impl AliasGetterSetter {
         data_type: AliasType,
         number: u16,
     ) -> Result<Option<DataValue>, StatusCode> {
-        let runtime = runtime.read().unwrap();
+        let runtime = runtime.read();
         let (table, address) = Table::table_from_number(number);
         let value = match table {
             Table::OutputCoils => {
@@ -448,7 +444,7 @@ impl AliasGetterSetter {
             Table::OutputCoils => {
                 let value = value.cast(VariantTypeId::Boolean);
                 if let Variant::Boolean(v) = value {
-                    let modbus = modbus.lock().unwrap();
+                    let modbus = modbus.lock();
                     modbus.write_to_coil(addr, v);
                     Ok(())
                 } else {
@@ -462,7 +458,7 @@ impl AliasGetterSetter {
                 // Write the words
                 let (_, words) =
                     Self::value_to_words(value).map_err(|_| StatusCode::BadUnexpectedError)?;
-                let modbus = modbus.lock().unwrap();
+                let modbus = modbus.lock();
                 modbus.write_to_registers(addr, words);
                 Ok(())
             }
@@ -484,7 +480,7 @@ impl AliasGetterSetter {
                 address
             );
         }
-        let values = values.read().unwrap();
+        let values = values.read();
         let idx = (address - base_address) as usize;
         Variant::from(*values.get(idx).unwrap())
     }
@@ -672,7 +668,7 @@ impl AliasGetterSetter {
         }
 
         let idx = (address - base_address) as usize;
-        let values = values.read().unwrap();
+        let values = values.read();
 
         if size == 1 {
             let w = *values.get(idx).unwrap();

--- a/samples/mqtt-client/Cargo.toml
+++ b/samples/mqtt-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+parking_lot = { version = "0.12", features = ["send_guard"] }
 pico-args = "0.3"
 # This is a completely arbitrary snapshot of rumqtt that happens to work
 rumqtt = { git = "https://github.com/AtherEnergy/rumqtt.git", rev = "83b4694525061e2ccef617c0ac867db2044cc4e7" }

--- a/samples/mqtt-client/src/main.rs
+++ b/samples/mqtt-client/src/main.rs
@@ -6,10 +6,11 @@
 //! values before exiting.
 use std::{
     path::PathBuf,
-    sync::{mpsc, Arc, Mutex, RwLock},
+    sync::{mpsc, Arc},
     thread,
 };
 
+use parking_lot::{Mutex, RwLock};
 use rumqtt::{MqttClient, MqttOptions, QoS};
 
 use opcua::client::prelude::*;
@@ -133,7 +134,7 @@ fn subscription_loop(
     // This scope is important - we don't want to session to be locked when the code hits the
     // loop below
     {
-        let session = session.read().unwrap();
+        let session = session.read();
 
         // Creates our subscription - one update every second. The update is sent as a message
         // to the MQTT thread to be published.
@@ -147,7 +148,7 @@ fn subscription_loop(
             true,
             DataChangeCallback::new(move |items| {
                 println!("Data change from server:");
-                let tx = tx.lock().unwrap();
+                let tx = tx.lock();
                 items.iter().for_each(|item| {
                     let node_id = item.item_to_monitor().node_id.clone();
                     let value = item.last_value().clone();

--- a/samples/simple-client/Cargo.toml
+++ b/samples/simple-client/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+parking_lot = { version = "0.12", features = ["send_guard"] }
 pico-args="0.3"
 
 [dependencies.opcua]

--- a/samples/simple-client/src/main.rs
+++ b/samples/simple-client/src/main.rs
@@ -7,7 +7,9 @@
 //! 1. Create a client configuration
 //! 2. Connect to an endpoint specified by the url with security None
 //! 3. Subscribe to values and loop forever printing out their values
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use opcua::client::prelude::*;
 
@@ -84,7 +86,7 @@ fn main() -> Result<(), ()> {
 }
 
 fn subscribe_to_variables(session: Arc<RwLock<Session>>, ns: u16) -> Result<(), StatusCode> {
-    let session = session.read().unwrap();
+    let session = session.read();
     // Creates a subscription with a data change callback
     let subscription_id = session.create_subscription(
         2000.0,

--- a/samples/simple-server/Cargo.toml
+++ b/samples/simple-server/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4"
 log = "0.4"
+parking_lot = { version = "0.12", features = ["send_guard"] }
 
 [dependencies.opcua]
 path = "../../lib"

--- a/samples/simple-server/src/main.rs
+++ b/samples/simple-server/src/main.rs
@@ -6,7 +6,9 @@
 //! adds some variables to the address space and the listeners for connections. It also has
 //! a timer that updates those variables so anything monitoring variables sees the values changing.
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use opcua::server::prelude::*;
 
@@ -20,7 +22,7 @@ fn main() {
 
     let ns = {
         let address_space = server.address_space();
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         address_space
             .register_namespace("urn:simple-server")
             .unwrap()
@@ -45,7 +47,7 @@ fn add_example_variables(server: &mut Server, ns: u16) {
 
     // The address space is guarded so obtain a lock to change it
     {
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
 
         // Create a sample folder under objects folder
         let sample_folder_id = address_space
@@ -71,7 +73,7 @@ fn add_example_variables(server: &mut Server, ns: u16) {
     //    function.
     {
         let address_space = server.address_space();
-        let mut address_space = address_space.write().unwrap();
+        let mut address_space = address_space.write();
         if let Some(ref mut v) = address_space.find_variable_mut(v3_node.clone()) {
             // Hello world's counter will increment with each get - slower interval == slower increment
             let mut counter = 0;
@@ -112,10 +114,10 @@ fn add_example_variables(server: &mut Server, ns: u16) {
         // Store a counter and a flag in a tuple
         let data = Arc::new(Mutex::new((0, true)));
         server.add_polling_action(300, move || {
-            let mut data = data.lock().unwrap();
+            let mut data = data.lock();
             data.0 += 1;
             data.1 = !data.1;
-            let mut address_space = address_space.write().unwrap();
+            let mut address_space = address_space.write();
             let now = DateTime::now();
             let _ = address_space.set_variable_value(v1_node.clone(), data.0 as i32, &now, &now);
             let _ = address_space.set_variable_value(v2_node.clone(), data.1, &now, &now);

--- a/samples/web-client/Cargo.toml
+++ b/samples/web-client/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2018"
 [dependencies]
 actix = "0.7"
 actix-web = "0.7"
+parking_lot = { version = "0.12", features = ["send_guard"] }
+pico-args = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-pico-args = "0.3"
 tokio = { version = "1", features = ["full"] }
 
 [dependencies.opcua]
 path = "../../lib"
 version = "0.11.0" # OPCUARustVersion
 features = ["client", "console-logging"]
-


### PR DESCRIPTION
@locka99 I understand this is a massive PR which also contains backwards incompatible changes, so let me try to explain why I think this PR is really worth it...

The main thing that this PR does, is switching from `std::sync::{Mutex, RwLock}` to `parking_lot::{Mutex, RwLock}`. This change is needed because `std::sync::{Mutex, RwLock}` cannot be shared between threads safely (a.k.a. it is missing the `std::marker::Send` trait) which is required when using it together with `futures::Future`:

```
std::sync::RwLockWriteGuard<'_, session::session::Session>` cannot be sent between threads
safely within `impl futures::Future`, the trait `std::marker::Send` is not implemented for 
`std::sync::RwLockWriteGuard<'_, session::session::Session>
```

I'm hitting this problem as I'm trying to create a full `async_client` without changing too much of the existing logic (so without trying to change mutexes to channels for example). So really just making the first step in having a full async client which can then be further optimized along the way, but can be used right away.

Initially I think it makes the most sense to add it next to the existing `client`, but of course it would be very nice (and much easier to maintain) if they can be merged one day. Yet before I can even offer a PR with a full `async_client` that we can talk about, I need to be able to use all the existing mutexes in async code which is not possible without switching to `parking_lot`.

Additionally I tried to fix as much Clippy warnings as I could to silence my editor a bit. These are all relatively small fixes which in no way change any of the logic! It just improves the code a tiny bit but adding small optimizations and rewriting a few loops or `if else` statements that should improve the efficiency or readability. But as you can see/test for yourself all the tests still pass and everything still works the same as before.

Last little thing I did in this PR (which I can revert if you want) is changing `~1.8` to just `1.8` for all `tokio` dependencies. Having it locked to `~1.8` means that any other project that wants to use this crate is forced to also use this exact same version. This caused some issues for us, so for now I stripped the `~`. If that is not acceptable I will add that back, but that would mean I need to maintain a fork to be able to use the client in our own project.

I really hope I can work with you to get this PR merged. I understand that changing to `parking_lot` could mean that some people using this crate (these crates) will need to update some of their code when they want to use the latest version. Yet the fix is as simple as only removing a few `.unwrap()` calls which the compiler will also tell you. So while it does have impact, I would argue the impact is very low and the potential gain (having a full async client) could be worth the pain...

Thanks and curious to hear your thoughts on this one!