### PR TITLE
Fix: constant time hash verification

### DIFF
--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -102,7 +102,7 @@ pub fn verify_hmac_sha1(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
         } else {
             trace!("Original signature = {:?}", signature);
             trace!("Calculated signature = {:?}", tmp_signature);
-            signature == &tmp_signature[..]
+            openssl::memcmp::eq(signature, &tmp_signature[..])
         }
     }
 }
@@ -128,7 +128,7 @@ pub fn verify_hmac_sha256(key: &[u8], data: &[u8], signature: &[u8]) -> bool {
         if hmac_sha256(key, data, &mut tmp_signature).is_err() {
             false
         } else {
-            signature == &tmp_signature[..]
+            openssl::memcmp::eq(signature, &tmp_signature[..])
         }
     }
 }


### PR DESCRIPTION
All credit goes to @phlay for pointing this out.

Using regular comparison on the byte slice will abort as soon as the first byte doesn't match. This could open up the system to timing attacks on the verification.
Using `openssl::memcmp::eq`, the comparison runs in constant-time.