### PR TITLE
fix: don't send CloseSession requests for unregistered sessions

### DIFF
--- a/client/src/session/session.rs
+++ b/client/src/session/session.rs
@@ -961,6 +961,11 @@ impl Session {
         if !self.is_connected() {
             return Err(StatusCode::BadNotConnected);
         }
+        // for some operations like enumerating endpoints, there is no session equivalent
+        // on the server and it's a local helper object, only. In that case: nothing to do.
+        if trace_read_lock_unwrap!(self.session_state).session_id().identifier == Identifier::Numeric(0) {
+            return Ok(());
+        }
         let request = CloseSessionRequest {
             delete_subscriptions: true,
             request_header: self.make_request_header(),


### PR DESCRIPTION
I noticed that some operations create a session object that isn't registered with the server but would result in `CloseSession` requests anyway. The best solution would have been to differentiate these two types of session but for now I just added a quick fix to check for the session id in order to determine whether to send `CloseSessionRequest` to the server...