### PR TITLE
Use tokio version "1"

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -25,7 +25,7 @@ chrono = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 futures = "0.3"
-tokio = { version = "~1.15", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 lazy_static = "1.4.0"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ serde_derive = "1.0"
 serde_yaml = "0.8"
 lazy_static = "1.4.0"
 futures = "0.3"
-tokio = { version = "~1.15", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 bytes = "1.0.1"
 url = "1.6"

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 bytes = "1.0.1"
-tokio = { version = "~1.15", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 
 [dependencies.opcua-core]

--- a/samples/web-client/Cargo.toml
+++ b/samples/web-client/Cargo.toml
@@ -11,7 +11,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 pico-args = "0.3"
-tokio = { version = "~1.15", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 
 [dependencies.opcua-client]
 path = "../../client"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -37,7 +37,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 lazy_static = "1.4.0"
-tokio = { version = "~1.15", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.6.9", features = ["codec"] }
 futures = "0.3"
 bitflags = "1.2"


### PR DESCRIPTION
We use tokio 1.16 internally meaning that we cannot select a compatible version when using this library as a dependency.

I only want the version requirements to be a little more lax, not necessarily `"1"` but I thought this could get us started :-)