### PR TITLE
Support missing VariantTypes

### DIFF
--- a/types/src/diagnostic_info.rs
+++ b/types/src/diagnostic_info.rs
@@ -46,7 +46,7 @@ bitflags! {
 }
 
 /// Diagnostic information.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct DiagnosticInfo {
     /// A symbolic name for the status code.
     pub symbolic_id: Option<i32>,

--- a/types/src/tests/encoding.rs
+++ b/types/src/tests/encoding.rs
@@ -386,6 +386,30 @@ fn variant() {
     // ExtensionObject
     let v = Variant::from(ExtensionObject::null());
     serialize_test(v);
+    // DataValue Variant
+    let v = Variant::from(DataValue {
+        value: Some(Variant::Double(1000f64)),
+        status: Some(StatusCode::GoodClamped),
+        source_timestamp: Some(DateTime::now()),
+        source_picoseconds: Some(333),
+        server_timestamp: Some(DateTime::now()),
+        server_picoseconds: Some(666),
+    });
+    serialize_test(v);
+    // Variant in Variant
+    let v = Variant::Variant(Box::new(Variant::from(8u8)));
+    serialize_test(v);
+    // Diagnostic
+    let v = Variant::from(DiagnosticInfo {
+        symbolic_id: Some(99),
+        namespace_uri: Some(437437),
+        locale: Some(333),
+        localized_text: Some(233),
+        additional_info: Some(UAString::from("Nested diagnostic")),
+        inner_status_code: Some(StatusCode::Good),
+        inner_diagnostic_info: None,
+    });
+    serialize_test(v);
     // DataValue
     let v = DataValue {
         value: Some(Variant::Double(1000f64)),

--- a/types/src/tests/variant.rs
+++ b/types/src/tests/variant.rs
@@ -5,8 +5,8 @@ use crate::{
     numeric_range::NumericRange,
     status_code::StatusCode,
     variant::{Variant, VariantTypeId},
-    ByteString, DataTypeId, DateTime, ExpandedNodeId, Guid, LocalizedText, NodeId, QualifiedName,
-    UAString,
+    ByteString, DataTypeId, DataValue, DateTime, DiagnosticInfo, ExpandedNodeId, Guid,
+    LocalizedText, NodeId, QualifiedName, UAString,
 };
 
 #[test]
@@ -82,6 +82,15 @@ fn variant_type_id() {
         (
             Variant::from(ExtensionObject::null()),
             VariantTypeId::ExtensionObject,
+        ),
+        (Variant::from(DataValue::null()), VariantTypeId::DataValue),
+        (
+            Variant::Variant(Box::new(Variant::from(32u8))),
+            VariantTypeId::Variant,
+        ),
+        (
+            Variant::from(DiagnosticInfo::null()),
+            VariantTypeId::Diagnostic,
         ),
         (Variant::from(vec![1]), VariantTypeId::Array),
     ];


### PR DESCRIPTION
Add support for missing Variants for DiagnosticInfo, DataValue and Variant. See issue: #170 