### PR TITLE
Make the logic to ignore clock skew more robust

### DIFF
--- a/client/src/session/session.rs
+++ b/client/src/session/session.rs
@@ -1443,6 +1443,13 @@ impl SessionService for Session {
                     let _ = secure_channel
                         .set_remote_cert_from_byte_string(&response.server_certificate);
                 }
+                // When ignoring clock skew, we calculate the time offset between the client
+                // and the server and use that to compensate for the difference in time.
+                if self.ignore_clock_skew && !response.response_header.timestamp.is_null() {
+                    let offset = response.response_header.timestamp - DateTime::now();
+                    // Update the client offset by adding the new offset.
+                    session_state.set_client_offset(offset);
+                }
                 session_state.session_id()
             };
 

--- a/client/src/session/session_state.rs
+++ b/client/src/session/session_state.rs
@@ -193,6 +193,11 @@ impl SessionState {
         self.id
     }
 
+    pub fn set_client_offset(&mut self, offset: Duration) {
+        self.client_offset = self.client_offset + offset;
+        debug!("Client offset set to {}", self.client_offset);
+    }
+
     pub fn set_session_id(&mut self, session_id: NodeId) {
         self.session_id = session_id
     }
@@ -452,15 +457,14 @@ impl SessionState {
             // server and use that offset to compensate for the difference in time when setting
             // the timestamps in the request headers and when decoding timestamps in messages
             // received from the server.
-            if self.ignore_clock_skew {
+            if self.ignore_clock_skew && !response.response_header.timestamp.is_null() {
                 let offset = response.response_header.timestamp - DateTime::now();
                 // Make sure to apply the offset to the security token in the current response.
                 security_token.created_at = security_token.created_at - offset;
                 // Update the client offset by adding the new offset. When the secure channel is
                 // renewed its already using the client offset calculated when issuing the secure
                 // channel and only needs to be updated to accommodate any additional clock skew.
-                self.client_offset = self.client_offset + offset;
-                debug!("Client offset set to {}", self.client_offset);
+                self.set_client_offset(offset);
             }
 
             debug!("Setting transport's security token");


### PR DESCRIPTION
We encounted a Heuft OPC server that didn’t send a timestamp in the `OpenSecureChannelResponse` message.

Yet it did send the correct timestamp in all other responses, so by adding a few more checks and also updating the offset on session creation fixes the problem.

And at the same time it can help to prevent new clock skew in cases where the channel is kept alive very long and new sessions are created within the existing channel.