### PR TITLE
[#189]: Fix detecting of failed connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ version = "0.10.0"
 dependencies = [
  "opcua",
  "pico-args",
+ "tokio 1.15.0",
 ]
 
 [[package]]

--- a/lib/src/client/client.rs
+++ b/lib/src/client/client.rs
@@ -397,7 +397,6 @@ impl Client {
                 self.session_retry_policy.clone(),
                 self.decoding_options(),
                 self.config.performance.ignore_clock_skew,
-                self.config.performance.single_threaded_executor,
             )));
             Ok(session)
         }
@@ -485,7 +484,6 @@ impl Client {
                 self.session_retry_policy.clone(),
                 self.decoding_options(),
                 self.config.performance.ignore_clock_skew,
-                self.config.performance.single_threaded_executor,
             );
             session.connect()?;
             let result = session.get_endpoints()?;

--- a/samples/simple-client/Cargo.toml
+++ b/samples/simple-client/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 pico-args="0.3"
+tokio = "1"
 
 [dependencies.opcua]
 path = "../../lib"


### PR DESCRIPTION
The client failed to detect a broken connection, as it didn't react on
a write error, aside from logging it.

This change makes it set the connection to finished when a write error
occurs, which will trigger a re-connect.

However, due to the fact that in a single session actually two Tokio
runtimes are involved, the session drops a Tokio runtime from an async
context, which will panic.

In order to fix this, this PR also removes the explicit Tokio runtimes
from the TCP comms and session struct. This means a breaking change,
as now the client functions need to be called with an active Tokio
context. This is easy as using `#[tokio::main]` and
`Handle::spawn_blocking` for the synchronous functions, but might
involve some more work in other scenarios.