### PR TITLE
types/variant: fix cast to i32 that might result in negative number

### DIFF
--- a/lib/src/types/variant.rs
+++ b/lib/src/types/variant.rs
@@ -789,11 +789,12 @@ impl BinaryEncoder<Variant> for Variant {
         // Read the value(s). If array length was specified, we assume a single or multi dimension array
         if array_length > 0 {
             // Array length in total cannot exceed max array length
-            if array_length > decoding_options.max_array_length as i32 {
+            let array_length = array_length as usize;
+            if array_length > decoding_options.max_array_length {
                 return Err(StatusCode::BadEncodingLimitsExceeded);
             }
 
-            let mut values: Vec<Variant> = Vec::with_capacity(array_length as usize);
+            let mut values: Vec<Variant> = Vec::with_capacity(array_length);
             for _ in 0..array_length {
                 values.push(Variant::decode_variant_value(
                     stream,


### PR DESCRIPTION
When array_length is decoded and greater than zero, the configured
decoding options are checked, casting max_array_length to i32. The type
is a usize. We set max_array_length = usize::MAX, resulting the cast to
produce -1 (as an i32) and returning BadEncodingLimitsExceeded.

Given that array_length is cast to a usize immediately after this check,
it makes sense to first convert to it to usize and perform the
comparison on usize instead of i32.