### PR TITLE
Fix memory leaks in connection management code

### DIFF
--- a/lib/src/client/comms/tcp_transport.rs
+++ b/lib/src/client/comms/tcp_transport.rs
@@ -20,8 +20,8 @@ use tokio::{
     self,
     io::{self, AsyncWriteExt, ReadHalf, WriteHalf},
     net::TcpStream,
-    sync::mpsc::{UnboundedReceiver, UnboundedSender},
-    time::{interval, Duration},
+    sync::mpsc::UnboundedReceiver,
+    time::Duration,
 };
 use tokio_util::codec::FramedRead;
 

--- a/lib/src/client/comms/tcp_transport.rs
+++ b/lib/src/client/comms/tcp_transport.rs
@@ -269,10 +269,7 @@ impl TcpTransport {
 
     /// Connects the stream to the specified endpoint
     pub fn connect(&self, endpoint_url: &str) -> Result<(), StatusCode> {
-        if self.is_connected() {
-            trace_read_lock!(self.message_queue).quit();
-        }
-
+        debug_assert!(!self.is_connected(), "Should not try to connect when already connected");
         let (host, port) =
             hostname_port_from_url(endpoint_url, constants::DEFAULT_OPC_UA_SERVER_PORT)?;
 

--- a/lib/src/client/comms/tcp_transport.rs
+++ b/lib/src/client/comms/tcp_transport.rs
@@ -401,7 +401,7 @@ impl TcpTransport {
         match framed_read.next().await {
             Some(Ok(Message::Acknowledge(ack))) => {
                 // TODO revise our sizes and other things according to the ACK
-                log::debug!("Received acknowledgement: {:?}", ack)
+                log::trace!("Received acknowledgement: {:?}", ack)
             }
             other => {
                 error!("Unexpected error while waiting for server ACK. Expected ACK, got {:?}", other);

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -573,7 +573,7 @@ impl Session {
             let _ = self.close_secure_channel();
 
             {
-                let mut session_state = trace_write_lock!(self.session_state);
+                let session_state = trace_read_lock!(self.session_state);
                 session_state.quit();
             }
 

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -140,7 +140,7 @@ pub struct Session {
     session_retry_policy: Arc<Mutex<SessionRetryPolicy>>,
     /// Ignore clock skew between the client and the server.
     ignore_clock_skew: bool,
-    /// Single threaded executor flag (for TCP transport)
+    /// Single threaded executor flag (for TCP transport). Unused.
     single_threaded_executor: bool,
     /// Tokio runtime
     runtime: Arc<Mutex<tokio::runtime::Runtime>>,

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -243,14 +243,7 @@ impl Session {
             self.subscription_state.clone(),
             self.message_queue.clone(),
         )));
-
-        // Create a new transport
-        self.transport = TcpTransport::new(
-            self.secure_channel.clone(),
-            self.session_state.clone(),
-            self.message_queue.clone(),
-            self.single_threaded_executor,
-        );
+        // Keep the existing transport, we should never drop a tokio runtime from a sync function
     }
 
     /// Connects to the server, creates and activates a session. If there

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -479,6 +479,7 @@ impl Session {
                     return Ok(());
                 }
                 Err(status_code) => {
+                    self.disconnect();
                     let mut session_retry_policy = trace_lock!(self.session_retry_policy);
                     session_retry_policy.increment_retry_count();
                     session_warn!(

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -368,7 +368,7 @@ impl SessionState {
     }
 
     pub(crate) fn quit(&self) {
-        let mut message_queue = trace_write_lock!(self.message_queue);
+        let message_queue = trace_read_lock!(self.message_queue);
         message_queue.quit();
     }
 

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 use chrono::Duration;
-
 use tokio::time::Instant;
 
 use crate::core::{
@@ -64,21 +63,13 @@ impl ConnectionStateMgr {
     }
 
     pub fn set_state(&self, state: ConnectionState) {
+        trace!("setting connection state to {:?}", state);
         let mut connection_state = trace_write_lock!(self.state);
         *connection_state = state;
     }
 
     pub fn set_finished(&self, finished_code: StatusCode) {
         self.set_state(ConnectionState::Finished(finished_code));
-    }
-
-    pub fn conditional_set_finished(&self, finished_code: StatusCode) -> bool {
-        if !self.is_finished() {
-            self.set_state(ConnectionState::Finished(finished_code));
-            true
-        } else {
-            false
-        }
     }
 
     pub fn is_connected(&self) -> bool {
@@ -376,7 +367,7 @@ impl SessionState {
         Ok(request_handle)
     }
 
-    pub(crate) fn quit(&mut self) {
+    pub(crate) fn quit(&self) {
         let mut message_queue = trace_write_lock!(self.message_queue);
         message_queue.quit();
     }

--- a/lib/src/core/comms/tcp_codec.rs
+++ b/lib/src/core/comms/tcp_codec.rs
@@ -12,12 +12,10 @@
 //! * OPN - Open Secure Channel message
 //! * CLO - Close Secure Channel message
 use std::io;
-use std::sync::Arc;
 
 use bytes::{BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::sync::*;
 use crate::types::{
     encoding::{BinaryEncoder, DecodingOptions},
     status_code::StatusCode,

--- a/lib/src/core/comms/tcp_codec.rs
+++ b/lib/src/core/comms/tcp_codec.rs
@@ -44,7 +44,6 @@ pub enum Message {
 /// messages so there is still some buffers within message chunks, but not at the raw socket level.
 pub struct TcpCodec {
     decoding_options: DecodingOptions,
-    abort: Arc<RwLock<bool>>,
 }
 
 impl Decoder for TcpCodec {
@@ -52,11 +51,7 @@ impl Decoder for TcpCodec {
     type Error = io::Error;
 
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        if self.is_abort() {
-            // Abort immediately
-            debug!("TcpCodec decode abort flag has been set and is terminating");
-            Err(io::Error::from(StatusCode::BadOperationAbandoned))
-        } else if buf.len() > MESSAGE_HEADER_LEN {
+        if buf.len() > MESSAGE_HEADER_LEN {
             // Every OPC UA message has at least 8 bytes of header to be read to see what follows
 
             // Get the message header
@@ -105,9 +100,8 @@ impl Encoder<Message> for TcpCodec {
 impl TcpCodec {
     /// Constructs a new TcpCodec. The abort flag is set to terminate the codec even while it is
     /// waiting for a frame to arrive.
-    pub fn new(abort: Arc<RwLock<bool>>, decoding_options: DecodingOptions) -> TcpCodec {
+    pub fn new(decoding_options: DecodingOptions) -> TcpCodec {
         TcpCodec {
-            abort,
             decoding_options,
         }
     }
@@ -122,11 +116,6 @@ impl TcpCodec {
             error!("Error writing message {:?}, err = {}", msg, err);
             io::Error::new(io::ErrorKind::Other, format!("Error = {}", err))
         })
-    }
-
-    fn is_abort(&self) -> bool {
-        let abort = self.abort.read();
-        *abort
     }
 
     /// Reads a message out of the buffer, which is assumed by now to be the proper length

--- a/lib/src/server/comms/tcp_transport.rs
+++ b/lib/src/server/comms/tcp_transport.rs
@@ -10,7 +10,6 @@
 //! Publish requests are sent based on the number of subscriptions and the responses / handling are
 //! left to asynchronous event handlers.
 use std::{collections::VecDeque, net::SocketAddr, sync::Arc};
-
 use chrono::{self, Utc};
 use futures::StreamExt;
 use tokio::{
@@ -23,6 +22,8 @@ use tokio::{
     sync::mpsc::{self, unbounded_channel, UnboundedReceiver, UnboundedSender},
     time::{interval_at, Duration, Instant},
 };
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
 use tokio_util::codec::FramedRead;
 
 use crate::core::{
@@ -54,16 +55,6 @@ const RECEIVE_BUFFER_SIZE: usize = std::u16::MAX as usize;
 const SEND_BUFFER_SIZE: usize = std::u16::MAX as usize;
 const MAX_MESSAGE_SIZE: usize = std::u16::MAX as usize;
 const MAX_CHUNK_COUNT: usize = 1;
-
-fn connection_finished(connection: Arc<RwLock<dyn Transport>>, id: &str) -> bool {
-    trace!("{}", id);
-    let connection = trace_read_lock!(connection);
-    let finished = connection.is_finished();
-    if finished {
-        info!("{} connection finished", id);
-    }
-    finished
-}
 
 /// Messages that may be sent to the writer.
 enum Message {
@@ -241,7 +232,7 @@ impl TcpTransport {
         }
 
         // Spawn the tasks we need to run
-        Self::spawn_session_handler_task(connection, socket, looping_interval_ms);
+        tokio::spawn(Self::spawn_session_handler_task(connection, socket, looping_interval_ms));
     }
 
     async fn write_bytes_task(mut write_state: WriteState) -> WriteState {
@@ -258,7 +249,7 @@ impl TcpTransport {
         write_state
     }
 
-    fn spawn_session_handler_task(
+    async fn spawn_session_handler_task(
         transport: Arc<RwLock<TcpTransport>>,
         socket: TcpStream,
         looping_interval_ms: f64,
@@ -274,24 +265,35 @@ impl TcpTransport {
         let send_buffer = Arc::new(Mutex::new(MessageWriter::new(send_buffer_size, 0, 0)));
 
         let (reader, writer) = socket.into_split();
-        let secure_channel = {
+        let (hello_timeout, secure_channel) = {
             let transport = trace_read_lock!(transport);
-            transport.secure_channel.clone()
+            let server_state = trace_read_lock!(transport.server_state);
+            let server_config = trace_read_lock!(server_state.config);
+            (server_config.tcp_config.hello_timeout, transport.secure_channel.clone())
         };
-
-        // This is set to true when the session is finished.
-        let finished_flag = Arc::new(RwLock::new(false));
-
-        // Spawn the hello timeout task, this timer waits for a hello and will abort
-        // session if it doesn't occur before the timeout.
-        Self::spawn_hello_timeout_task(transport.clone(), tx.clone(), session_start_time);
 
         // Spawn all the tasks that monitor the session - the subscriptions, finished state,
         // reading and writing.
-        Self::spawn_subscriptions_task(transport.clone(), tx.clone(), looping_interval_ms);
-        Self::spawn_finished_monitor_task(transport.clone(), finished_flag.clone());
-        Self::spawn_writing_loop_task(writer, rx, secure_channel, transport.clone(), send_buffer);
-        Self::spawn_reading_loop_task(reader, finished_flag, transport, tx, receive_buffer_size);
+        let final_status = tokio::select! {
+            _ = Self::spawn_subscriptions_task(transport.clone(), tx.clone(), looping_interval_ms) => {
+                log::trace!("Closing connection because the subscription task failed");
+                Ok(())
+            }
+            status = Self::spawn_writing_loop_task(writer, rx, secure_channel, transport.clone(), send_buffer) => {
+                log::trace!("Closing connection after the write task ended");
+                status
+            }
+            status = Self::spawn_reading_loop_task(reader, transport.clone(), tx, hello_timeout) => {
+                log::trace!("Closing connection after the read task ended");
+                status
+            }
+        }.err().unwrap_or(StatusCode::Good);
+
+        log::info!("Closing connection with status {}", final_status);
+        // Both the read and write halves of the tcp stream are dropped at this point,
+        // and the connection is closed
+        let mut transport = trace_write_lock!(transport);
+        transport.finish(final_status);
     }
 
     fn make_debug_task_id(component: &str, transport: Arc<RwLock<TcpTransport>>) -> String {
@@ -336,13 +338,13 @@ impl TcpTransport {
 
     /// Spawns the writing loop task. The writing loop takes messages to send off of a queue
     /// and sends them to the stream.
-    fn spawn_writing_loop_task(
+    async fn spawn_writing_loop_task(
         writer: OwnedWriteHalf,
         mut receiver: UnboundedReceiver<Message>,
         secure_channel: Arc<RwLock<SecureChannel>>,
         transport: Arc<RwLock<TcpTransport>>,
         send_buffer: Arc<Mutex<MessageWriter>>,
-    ) {
+    ) -> Result<(), StatusCode> {
         let mut write_state = WriteState {
             transport: transport.clone(),
             writer,
@@ -351,86 +353,72 @@ impl TcpTransport {
         };
 
         // The writing task waits for messages that are to be sent
-        tokio::spawn(async move {
-            let id = Self::make_debug_task_id("server_writing_loop_task", transport.clone());
-            register_runtime_component!(&id);
-            loop {
-                let msg = receiver.recv().await;
-                if msg.is_none() {
-                    continue;
+        let id = Self::make_debug_task_id("server_writing_loop_task", transport.clone());
+        register_runtime_component!(&id);
+        while let Some(message) = receiver.recv().await {
+            trace!("write_looping_task.take_while");
+            let (request_id, response) = match message {
+                Message::Quit => {
+                    debug!("Server writer received a quit so it will quit");
+                    return Ok(());
                 }
-                let message = msg.unwrap();
-                trace!("write_looping_task.take_while");
-                let (request_id, response) = match message {
-                    Message::Quit => {
-                        debug!("Server writer received a quit so it will quit");
-                        let _ = write_state.writer.shutdown().await;
-                        break;
+                Message::Message(request_id, response) => {
+                    if let SupportedMessage::Invalid(_) = response {
+                        error!("Writer terminating - received an invalid message");
+                        return Err(StatusCode::BadCommunicationError);
                     }
-                    Message::Message(request_id, response) => {
-                        let mut transport = trace_write_lock!(write_state.transport);
-                        if let SupportedMessage::Invalid(_) = response {
-                            error!("Writer terminating - received an invalid message");
-                            transport.finish(StatusCode::BadCommunicationError);
-                            break;
-                        } else if transport.is_server_abort() {
-                            info!("Writer terminating - communication error (abort)");
-                            transport.finish(StatusCode::BadCommunicationError);
-                            break;
-                        } else if transport.is_finished() {
-                            info!("Writer terminating - transport is finished");
-                            break;
-                        }
-                        (request_id, response)
-                    }
-                };
-
-                {
-                    let secure_channel = trace_read_lock!(write_state.secure_channel);
-                    let mut send_buffer = trace_lock!(write_state.send_buffer);
-                    match response {
-                        SupportedMessage::AcknowledgeMessage(ack) => {
-                            let _ = send_buffer.write_ack(&ack);
-                        }
-                        msg => {
-                            let _ = send_buffer.write(request_id, msg, &secure_channel);
-                        }
-                    }
+                    (request_id, response)
                 }
+            };
 
-                write_state = Self::write_bytes_task(write_state).await;
-
-                let finished = {
-                    let transport = trace_read_lock!(write_state.transport);
-                    transport.is_finished()
-                };
-                if finished {
-                    info!("Writer session status is terminating");
-                    let _ = write_state.writer.shutdown().await;
-                    break;
+            {
+                let secure_channel = trace_read_lock!(write_state.secure_channel);
+                let mut send_buffer = trace_lock!(write_state.send_buffer);
+                match response {
+                    SupportedMessage::AcknowledgeMessage(ack) => {
+                        let _ = send_buffer.write_ack(&ack);
+                    }
+                    msg => {
+                        let _ = send_buffer.write(request_id, msg, &secure_channel);
+                    }
                 }
             }
+            write_state = Self::write_bytes_task(write_state).await;
+        }
+        Ok(())
+    }
 
-            // Mark as finished in the case that something else didn't
-            let mut transport = trace_write_lock!(write_state.transport);
-            if !transport.is_finished() {
-                error!("Write bytes task is in error and is finishing the transport");
-                transport.finish(StatusCode::BadCommunicationError);
-            } else {
-                error!("Write bytes task is in error");
-            };
-            trace!("Write bytes task finished");
-            deregister_runtime_component!(&id);
-        });
+    async fn wait_for_hello(
+        reader: &mut FramedRead<OwnedReadHalf, TcpCodec>,
+        hello_timeout: u32,
+    ) -> Result<HelloMessage, StatusCode> {
+        let duration = Duration::from_secs(u64::from(hello_timeout));
+        match timeout(duration, reader.next()).await {
+            // We process a timeout(stream_element(tcp_message))
+            Err(_timeout) => {
+                warn!("Session has been waiting for a hello for more than the timeout period and will now close");
+                Err(StatusCode::BadTimeout)
+            }
+            Ok(Some(Ok(tcp_codec::Message::Hello(hello)))) => Ok(hello),
+            Ok(Some(Ok(bad_msg))) => {
+                log::error!("Expected a hello message, got {:?} instead", bad_msg);
+                Err(StatusCode::BadCommunicationError)
+            }
+            Ok(Some(Err(communication_err))) => {
+                error!("Communication error while waiting for Hello message: {}", communication_err);
+                Err(StatusCode::BadCommunicationError)
+            }
+            Ok(None) => Err(StatusCode::BadConnectionClosed),
+        }
     }
 
     /// Creates the framed read task / future. This will read chunks from the
     /// reader and process them.
     async fn framed_read_task(
         reader: OwnedReadHalf,
-        finished_flag: Arc<RwLock<bool>>,
         read_state: ReadState,
-    ) {
+        hello_timeout: u32,
+    ) -> Result<(), StatusCode> {
         let (transport, mut sender) = { (read_state.transport.clone(), read_state.sender.clone()) };
 
         let decoding_options = {
@@ -441,200 +429,49 @@ impl TcpTransport {
 
         // The reader reads frames from the codec, which are messages
         let mut framed_read =
-            FramedRead::new(reader, TcpCodec::new(finished_flag, decoding_options));
-        loop {
-            if connection_finished(transport.clone(), "Server reader loop") {
-                break;
-            }
+            FramedRead::new(reader, TcpCodec::new(decoding_options));
 
-            let next_msg = framed_read.next().await;
-            if next_msg.is_none() {
-                continue;
-            }
+        let hello = Self::wait_for_hello(&mut framed_read, hello_timeout).await?;
+        trace_write_lock!(transport).process_hello(hello, &mut sender)?;
 
-            let transport_state = {
-                let transport = trace_read_lock!(transport);
-                transport.transport_state
-            };
-
-            match next_msg.unwrap() {
+        while let Some(next_msg) = framed_read.next().await {
+            match next_msg {
                 Ok(message) => {
-                    let mut session_status_code = StatusCode::Good;
-                    match transport_state {
-                        TransportState::WaitingHello => {
-                            if let tcp_codec::Message::Hello(hello) = message {
-                                let mut transport = trace_write_lock!(transport);
-                                if let Err(err) = transport.process_hello(hello, &mut sender) {
-                                    session_status_code = err;
-                                }
-                            } else {
-                                session_status_code = StatusCode::BadCommunicationError;
-                            }
-                        }
-                        TransportState::ProcessMessages => {
-                            if let tcp_codec::Message::Chunk(chunk) = message {
-                                let mut transport = trace_write_lock!(transport);
-                                if let Err(err) = transport.process_chunk(chunk, &mut sender) {
-                                    session_status_code = err;
-                                }
-                            } else {
-                                session_status_code = StatusCode::BadCommunicationError;
-                            }
-                        }
-                        _ => {
-                            error!("Server reader unknown session state, aborting");
-                            session_status_code = StatusCode::BadUnexpectedError;
-                        }
-                    }
-                    // Update the session status and drop out
-                    if session_status_code.is_bad() {
-                        error!(
-                            "Server reader session status is {} so finishing",
-                            session_status_code
-                        );
+                    if let tcp_codec::Message::Chunk(chunk) = message {
                         let mut transport = trace_write_lock!(transport);
-                        transport.finish(session_status_code);
-                        break;
+                        transport.process_chunk(chunk, &mut sender)?
+                    } else {
+                        return Err(StatusCode::BadCommunicationError);
                     }
                 }
                 Err(err) => {
-                    // Mark as finished just in case something else didn't
-                    let mut transport = trace_write_lock!(transport);
-                    if !transport.is_finished() {
-                        error!(
-                            "Server reader is in error and is finishing the transport. {:?}",
-                            err
-                        );
-                        transport.finish(StatusCode::BadCommunicationError);
-                    } else {
-                        error!("Server reader error {:?}", err);
-                    }
-                    break;
+                    error!("Server reader error {:?}", err);
+                    return Err(StatusCode::BadCommunicationError);
                 }
             }
         }
-        let mut transport = trace_write_lock!(transport);
-        if !transport.is_finished() {
-            error!("Server reader stopped and is finishing the transport.");
-            transport.finish(StatusCode::Good);
-        }
+        Ok(())
     }
 
     /// Spawns the reading loop where a reader task continuously reads messages, chunks from the
     /// input and process them. The reading task will terminate upon error.
-    fn spawn_reading_loop_task(
+    async fn spawn_reading_loop_task(
         reader: OwnedReadHalf,
-        finished_flag: Arc<RwLock<bool>>,
         transport: Arc<RwLock<TcpTransport>>,
         sender: UnboundedSender<Message>,
-        receive_buffer_size: usize,
-    ) {
+        hello_timeout: u32,
+    ) -> Result<(), StatusCode> {
         // Connection state is maintained for looping through each task
         let read_state = ReadState {
             transport: transport.clone(),
             bytes_read: 0,
             sender: sender.clone(),
         };
-
-        tokio::spawn(async move {
-            let id = Self::make_debug_task_id("server_reading_loop_task", transport.clone());
-            register_runtime_component!(&id);
-
-            Self::framed_read_task(reader, finished_flag.clone(), read_state).await;
-
-            // Some handlers might wish to send their message and terminate, in which case this is
-            // done here.
-            {
-                // Terminate may have been set somewhere
-                let mut transport = trace_write_lock!(transport);
-                let sessions_terminated = {
-                    let session_manager = transport.session_manager();
-                    let session_manager = trace_read_lock!(session_manager);
-                    session_manager.sessions_terminated()
-                };
-                if sessions_terminated {
-                    transport.finish(StatusCode::BadConnectionClosed);
-                }
-            };
-            info!("Read loop is finished");
-            debug!("Server reader task is sending a quit to the server writer");
-            let _ = sender.send(Message::Quit);
-            deregister_runtime_component!(&id);
-        });
-    }
-
-    /// Makes the tokio task that looks for a hello timeout event, i.e. the connection is opened
-    /// but no hello is received and we need to drop the session
-    fn spawn_hello_timeout_task(
-        transport: Arc<RwLock<TcpTransport>>,
-        sender: UnboundedSender<Message>,
-        session_start_time: chrono::DateTime<Utc>,
-    ) {
-        let hello_timeout = {
-            let hello_timeout = {
-                let transport = trace_read_lock!(transport);
-                let server_state = trace_read_lock!(transport.server_state);
-                let server_config = trace_read_lock!(server_state.config);
-                server_config.tcp_config.hello_timeout as i64
-            };
-            chrono::Duration::seconds(hello_timeout)
-        };
-
-        // Clone the connection so the take_while predicate has its own instance
-        tokio::spawn(async move {
-            let id = Self::make_debug_task_id("hello_timeout_task", transport.clone());
-            register_runtime_component!(&id);
-
-            let mut timer = interval_at(
-                Instant::now(),
-                Duration::from_millis(constants::HELLO_TIMEOUT_POLL_MS),
-            );
-            loop {
-                trace!("hello_timeout_task.take_while");
-                // Terminates when session is no longer waiting for a hello or connection is done
-                {
-                    let transport = trace_read_lock!(transport);
-                    let waiting_for_hello = !transport.has_received_hello();
-                    if !waiting_for_hello {
-                        debug!("Hello timeout timer no longer required & is going to stop");
-                        break;
-                    }
-                }
-
-                timer.tick().await;
-
-                // Check if the session has waited in the hello state for more than the hello timeout period
-                let transport_state = {
-                    let transport = trace_read_lock!(transport);
-                    transport.state()
-                };
-                if transport_state == TransportState::WaitingHello {
-                    // Check if the time elapsed since the session started exceeds the hello timeout
-                    let now = Utc::now();
-                    let duration_since_start = now.signed_duration_since(session_start_time);
-                    if duration_since_start.num_milliseconds() > hello_timeout.num_milliseconds() {
-                        // Check if the session has waited in the hello state for more than the hello timeout period
-                        info!("Session has been waiting for a hello for more than the timeout period and will now close");
-                        let mut transport = trace_write_lock!(transport);
-                        transport.finish(StatusCode::BadTimeout);
-
-                        // Diagnostics
-                        let server_state = trace_read_lock!(transport.server_state);
-                        let mut diagnostics = trace_write_lock!(server_state.diagnostics);
-                        diagnostics.on_session_timeout();
-
-                        // Make sure sockets go down
-                        let _ = sender.send(Message::Quit);
-                    }
-                }
-            }
-            info!("Hello timeout is finished");
-            deregister_runtime_component!(&id);
-        });
+        Self::framed_read_task(reader, read_state, hello_timeout).await
     }
 
     /// Start the subscription timer to service subscriptions
-    fn spawn_subscriptions_task(
+    async fn spawn_subscriptions_task(
         transport: Arc<RwLock<TcpTransport>>,
         sender: UnboundedSender<Message>,
         looping_interval_ms: f64,
@@ -662,19 +499,15 @@ impl TcpTransport {
                 // Creates a repeating interval future that checks subscriptions.
                 let mut timer = interval_at(Instant::now(), interval_duration);
 
-                loop {
-                    if connection_finished(transport.clone(), "subscriptions_task loop") {
-                        break;
-                    }
-
+                'sub: loop {
                     timer.tick().await;
 
                     let transport = trace_read_lock!(transport);
                     let session_manager = trace_read_lock!(transport.session_manager);
                     let address_space = trace_read_lock!(transport.address_space);
 
-                    session_manager.sessions.iter().for_each(|s| {
-                        let mut session = trace_write_lock!(s.1);
+                    for (_node_id, session) in session_manager.sessions.iter() {
+                        let mut session = trace_write_lock!(session);
                         let now = Utc::now();
 
                         // Request queue might contain stale publish requests
@@ -691,61 +524,50 @@ impl TcpTransport {
 
                         // Check if there are publish responses to send for transmission
                         if let Some(publish_responses) =
-                            session.subscriptions_mut().take_publish_responses()
+                        session.subscriptions_mut().take_publish_responses()
                         {
                             match subscription_tx
                                 .send(SubscriptionEvent::PublishResponses(publish_responses))
                             {
                                 Err(error) => {
-                                    error!("Cannot send publish responses, err = {}", error)
+                                    error!("Exiting subscription timer task because the subscription receiver was closed {}", error);
+                                    break 'sub;
                                 }
                                 Ok(_) => trace!("Sent publish responses to session task"),
                             }
                         }
-                    });
+                    }
                 }
                 info!("Subscription monitor is finished");
                 deregister_runtime_component!(&id);
             });
         }
 
-        // Create the receiving task - this takes publish responses and sends them back to the client
-        {
-            tokio::spawn(async move {
-                let id = Self::make_debug_task_id("subscriptions_task_receiver", transport.clone());
-                register_runtime_component!(&id);
-
-                loop {
-                    if connection_finished(transport.clone(), "subscriptions_task loop") {
-                        break;
-                    }
-                    // Process publish response events
-                    if let Some(subscription_event) = subscription_rx.recv().await {
-                        match subscription_event {
-                            SubscriptionEvent::PublishResponses(publish_responses) => {
-                                trace!(
+        // Create the receiving loop: takes publish responses and sends them back to the client
+        let id = Self::make_debug_task_id("subscriptions_task_receiver", transport.clone());
+        register_runtime_component!(&id);
+        // Process publish response events
+        while let Some(subscription_event) = subscription_rx.recv().await {
+            match subscription_event {
+                SubscriptionEvent::PublishResponses(publish_responses) => {
+                    trace!(
                                     "Got {} PublishResponse messages to send",
                                     publish_responses.len()
                                 );
-                                for publish_response in publish_responses {
-                                    trace!(
+                    for publish_response in publish_responses {
+                        trace!(
                                         "<-- Sending a Publish Response{}, {:?}",
                                         publish_response.request_id,
                                         &publish_response.response
                                     );
-                                    // Messages will be sent by the writing task
-                                    let _ = sender.send(Message::Message(
-                                        publish_response.request_id,
-                                        publish_response.response,
-                                    ));
-                                }
-                            }
-                        }
+                        // Messages will be sent by the writing task
+                        let _ = sender.send(Message::Message(
+                            publish_response.request_id,
+                            publish_response.response,
+                        ));
                     }
                 }
-                info!("Subscription receiver is finished");
-                deregister_runtime_component!(&id);
-            });
+            }
         }
     }
 
@@ -765,7 +587,7 @@ impl TcpTransport {
             let server_state = trace_read_lock!(self.server_state);
             server_state.endpoints(&hello.endpoint_url, &None)
         }
-        .unwrap();
+            .unwrap();
 
         trace!("Server received HELLO {:?}", hello);
         if !hello.is_endpoint_url_valid(&endpoints) {


### PR DESCRIPTION
This revamps the connection handling on both the client and the server
to guarantee that we never have rogue tokio tasks running.

This simplifies the connection management code by using native rust and tokio
future cancelling to make sure all concurrent code stops when a connection dies,
whatever the reason.

This allows removing a lot of complex connection state management code.

In the new design, if either the read or the write loop needs to terminate the connection, it can do so by simply returning from the current function.

Fixes #199
Fixes #179

This is a base for future pull requests, that I am afraid to do with the current complex state management code.