### PR TITLE
Use DateTime for token creation time

### DIFF
--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -176,7 +176,7 @@ impl SecureChannel {
     pub fn set_security_token(&mut self, channel_token: ChannelSecurityToken) {
         self.secure_channel_id = channel_token.channel_id;
         self.token_id = channel_token.token_id;
-        self.token_created_at = channel_token.created_at;
+        self.token_created_at = DateTime::now();
         self.token_lifetime = channel_token.revised_lifetime;
     }
 


### PR DESCRIPTION
SecureChannel.token_created_at was set using the OPC server time which could cause connection failures if the OPC server is not configured correctly.
Changed so that the same time source is used to determine the token lifetime (DateTime::now())
Fixes #206 