### PR TITLE
generate types and enums from nodeset

### DIFF
--- a/tools/schema/gen_datatypes.js
+++ b/tools/schema/gen_datatypes.js
@@ -13,4 +13,8 @@ let argv = require("yargs")
 let bsd_file = argv.bsd;
 let rs_module = argv.module;
 
-types.from_xml(bsd_file, rs_module);
+if (bsd_file.includes('.xml')) {
+    types.from_nodeset(bsd_file, rs_module);
+} else {
+    types.from_xml(bsd_file, rs_module);
+}


### PR DESCRIPTION
Uses the nodeset `<Definition>` to generate types and enums
Also generates Unions, which have it's binary codec defined here:
https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.8/ 

Probably the CLI args of types.js could be better.
Would like to know how you think it should be done
Add another arg for a nodeset file, rename the bsd arg,
or create another .js file? Then i'll properly edit the README.md

Also, looks like you already thought about `<Definition>` here:
https://github.com/locka99/opcua/blob/b7e7573a48771a55a79819c3e15e66267e8b7ab3/tools/schema/nodeset.js#L375
Would you like that the xml decoding code to be there?

Thanks!