### PR TITLE
Set MaxBrowsePoints datatype as u16

### DIFF
--- a/lib/src/server/address_space/address_space.rs
+++ b/lib/src/server/address_space/address_space.rs
@@ -314,7 +314,7 @@ impl AddressSpace {
                 );
                 self.set_variable_value(
                     Server_ServerCapabilities_MaxBrowseContinuationPoints,
-                    constants::MAX_BROWSE_CONTINUATION_POINTS as u32,
+                    constants::MAX_BROWSE_CONTINUATION_POINTS as u16,
                     &now,
                     &now,
                 );


### PR DESCRIPTION
This updates the cast of MaxBrowseContinuationPoints to match the UInt16 datatype as specified in the schema.