### PR TITLE
fix out of order address_space/session locking causing deadlock

### DIFF
--- a/lib/src/server/comms/tcp_transport.rs
+++ b/lib/src/server/comms/tcp_transport.rs
@@ -456,10 +456,10 @@ impl TcpTransport {
 
             let transport = trace_read_lock!(transport);
             let session_manager = trace_read_lock!(transport.session_manager);
-            let address_space = trace_read_lock!(transport.address_space);
 
             for (_node_id, session) in session_manager.sessions.iter() {
                 let mut session = trace_write_lock!(session);
+                let address_space = trace_read_lock!(transport.address_space);
                 let now = Utc::now();
 
                 // Request queue might contain stale publish requests


### PR DESCRIPTION
Currently, `server/services/session.rs:activate_session`, locks `session`, then later in `server/events/audit/mod.rs:AuditLog::raise_and_log`, locks `address_space`. Meanwhile `spawn_subscription_task` locks `address_space` then `session`. This reorders the `spawn_subscription_task` lock ordering to match. 
