### PR TITLE
fix out of order locking between server_state and session_manager 

### DIFF
--- a/lib/src/server/services/session.rs
+++ b/lib/src/server/services/session.rs
@@ -334,8 +334,6 @@ impl SessionService {
         address_space: Arc<RwLock<AddressSpace>>,
         request: &CloseSessionRequest,
     ) -> SupportedMessage {
-        let server_state = trace_write_lock!(server_state);
-
         info!(
             "close_session with authentication token {}",
             &request.request_header.authentication_token
@@ -353,6 +351,7 @@ impl SessionService {
             };
 
             {
+                let server_state = trace_write_lock!(server_state);
                 let mut session = trace_write_lock!(session);
 
                 // From spec: When the CloseSession Service is called before the Session is


### PR DESCRIPTION
fix out of order locking between server_state and session_manager causing deadlock.

Deadlock occurred in the following scenario:

```
thread 1:
spawn_reading_loop_task:
	tcp_transport.rs:423:		transport.write_lock
handle_message():
	message_handler.rs:124		session_manager.write_lock
create_session()
	session.rs:45			server_state.write_lock

thread 2:
spawn_reading_loop_task
	tcp_transport.rs:423		transport.write_lock
close_session:
	session.rs:337			server_state.write_lock
	session.rs:345			session_manager.read_lock
```
