### PR TITLE
Prevent server instance from crashing when the service port is being crossed by a non-conforming process

### DIFF
--- a/lib/src/server/comms/tcp_transport.rs
+++ b/lib/src/server/comms/tcp_transport.rs
@@ -220,8 +220,13 @@ impl TcpTransport {
         // Store the address of the client
         let (send_buffer_size, receive_buffer_size) = {
             let mut connection = trace_write_lock!(connection);
-            connection.client_address = Some(socket.peer_addr().unwrap());
-            connection.transport_state = TransportState::WaitingHello;
+            if socket.peer_addr().is_ok() {
+                connection.client_address = Some(socket.peer_addr().unwrap());
+                connection.transport_state = TransportState::WaitingHello;
+            } else {
+                connection.client_address = None;
+                connection.transport_state = TransportState::Finished(StatusCode::IS_ERROR);
+            }
             let server_state = trace_read_lock!(connection.server_state);
             (
                 server_state.send_buffer_size,


### PR DESCRIPTION
I was running the simple-server sample, but the same behaviour occurs with demo-server.
Having changed:
``` diff
diff --git a/samples/server.conf b/samples/server.conf
index 0937e846..2604d1f3 100644
--- a/samples/server.conf
+++ b/samples/server.conf
@@ -9,7 +9,7 @@ certificate_validation:
   trust_client_certs: false
   check_time: true
 pki_dir: "./pki"
-discovery_server_url: "opc.tcp://localhost:4840/UADiscovery"
+discovery_server_url: "opc.tcp://127.0.0.1:4840/UADiscovery"
 tcp_config:
   hello_timeout: 5
   host: 127.0.0.1
```
issuing `RUST_BACKTRACE=1 cargo run` in `samples/simple-server` I get
```
2023-06-20 12:01:09.296 ERROR opcua::client::comms::tcp_transport      Could not connect to host 127.0.0.1:4840, Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }
2023-06-20 12:01:09.296 ERROR opcua::client::session::session          session:1 Session has given up trying to connect to the server after 1 retries
2023-06-20 12:01:09.296 ERROR opcua::client::client                    Cannot connect to opc.tcp://127.0.0.1:4840/UADiscovery - check this error - BadNotConnected
2023-06-20 12:01:09.296 ERROR opcua::server::discovery                 Cannot find servers on discovery url opc.tcp://127.0.0.1:4840/UADiscovery, error = IS_ERROR | BadInternalError | BadEncodingLimitsExceeded | BadTimeout | BadTcpMessageTooLarge | BadTcpInternalError | BadSequenceNumberInvalid | BadNotConnected
```
A client I put together connects regardless and periodically outputs the
changing set of values according to its subscription successfully.

Once one runs `nmap -p 4800-4900 -Pn 127.0.0.1` though, the server crashes entirely:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" }', lib/src/server/comms/tcp_transport.rs:223:65
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/panicking.rs:578:5
   1: core::panicking::panic_fmt
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/panicking.rs:67:14
   2: core::result::unwrap_failed
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/result.rs:1687:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/result.rs:1089:23
   4: opcua::server::comms::tcp_transport::TcpTransport::run
             at /home/fldiet/opcua/github/opcua/lib/src/server/comms/tcp_transport.rs:223:46
   5: opcua::server::server::Server::handle_connection
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:658:9
   6: opcua::server::server::Server::server_task::{{closure}}::{{closure}}
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:364:33
   7: opcua::server::server::Server::server_task::{{closure}}::{{closure}}
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/macros/select.rs:507:49
   8: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/future/poll_fn.rs:38:9
   9: opcua::server::server::Server::server_task::{{closure}}
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:347:9
  10: opcua::server::server::Server::new_server_task::{{closure}}
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:299:90
  11: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/park/thread.rs:263:54
  12: tokio::coop::with_budget::{{closure}}
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/coop.rs:102:9
  13: std::thread::local::LocalKey<T>::try_with
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/thread/local.rs:252:16
  14: std::thread::local::LocalKey<T>::with
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/thread/local.rs:228:9
  15: tokio::coop::with_budget
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/coop.rs:95:5
  16: tokio::coop::budget
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/coop.rs:72:5
  17: tokio::park::thread::CachedParkThread::block_on
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/park/thread.rs:263:31
  18: tokio::runtime::enter::Enter::block_on
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/runtime/enter.rs:152:13
  19: tokio::runtime::thread_pool::ThreadPool::block_on
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/runtime/thread_pool/mod.rs:90:9
  20: tokio::runtime::Runtime::block_on
             at /home/fldiet/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.20.1/src/runtime/mod.rs:484:43
  21: opcua::server::server::Server::run_server_on_runtime
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:260:13
  22: opcua::server::server::Server::run_server
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:243:9
  23: opcua::server::server::Server::run
             at /home/fldiet/opcua/github/opcua/lib/src/server/server.rs:223:9
  24: opcua_simple_server::main
             at ./src/main.rs:34:5
  25: core::ops::function::FnOnce::call_once
             at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Catching the scenario rustc complains about while ignoring the affected `TransportState`
the server does not crash anymore, but the client stops receiving value change events
from its subscription once `nmap` has been sent on its way, effectively forcing it to reconnect.

Considering the `TransportState` as well neither does the server crash, nor is
the client prevented from receiving continuous data updates.

This change is reflected in the proposed commit.
