### PR TITLE
Fix : Panic and subscription deadlock on reconnect 

### DIFF
--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -210,10 +210,12 @@ impl Session {
         }
 
         // Create a new session state
-        self.session_state = Arc::new(RwLock::new(SessionState::new(
+        let exisisting_message_queue = self.session_state.read().message_queue.clone();
+        self.session_state = Arc::new(RwLock::new(SessionState::new_with_message_queue(
             self.ignore_clock_skew,
             self.secure_channel.clone(),
             self.subscription_state.clone(),
+            exisisting_message_queue, 
         )));
 
         // Keep the existing transport, we should never drop a tokio runtime from a sync function

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -681,12 +681,16 @@ impl Session {
             }
         };
         // Spawn the task on the alloted runtime
-        let runtime = {
-            let session = trace_read_lock!(session);
-            session.runtime.clone()
-        };
-        let runtime = trace_lock!(runtime);
-        runtime.block_on(task);
+        // let runtime = {
+        //     let session = trace_read_lock!(session);
+        //     session.runtime.clone()
+        // };
+        // let runtime = trace_lock!(runtime);
+        // runtime.block_on(task);
+
+        // The above code didn't release the lock and allow the subscriptions to respawn on reconnect.
+        // Creating a fresh runtime to run the session task as it's independent.
+        tokio::runtime::Runtime::new().unwrap().block_on(task);
     }
 
     /// Polls on the session which basically dispatches any pending

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -186,7 +186,41 @@ impl SessionState {
             session_closed_callback: None,
             connection_status_callback: None,
             message_queue: Arc::new(RwLock::new(MessageQueue::new())),
+    }
+
+    pub fn new_with_message_queue(
+        ignore_clock_skew: bool,
+        secure_channel: Arc<RwLock<SecureChannel>>,
+        subscription_state: Arc<RwLock<SubscriptionState>>,
+        message_queue: Arc<RwLock<MessageQueue>>,
+    ) -> SessionState {
+        let id = NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed);
+        {
+            let mq = message_queue.read();
+            debug!("### SessionState new_with_message_queue has id: {}, and messag_queue id: {}", id, mq.mq_id);
         }
+        let ss = SessionState {
+            id,
+            client_offset: Duration::zero(),
+            ignore_clock_skew,
+            secure_channel,
+            connection_state: ConnectionStateMgr::new(),
+            request_timeout: Self::DEFAULT_REQUEST_TIMEOUT,
+            send_buffer_size: Self::SEND_BUFFER_SIZE,
+            receive_buffer_size: Self::RECEIVE_BUFFER_SIZE,
+            max_message_size: Self::MAX_BUFFER_SIZE,
+            max_chunk_count: constants::MAX_CHUNK_COUNT,
+            request_handle: Handle::new(Self::FIRST_REQUEST_HANDLE),
+            session_id: NodeId::null(),
+            authentication_token: NodeId::null(),
+            monitored_item_handle: Handle::new(Self::FIRST_MONITORED_ITEM_HANDLE),
+            subscription_acknowledgements: Vec::new(),
+            subscription_state,
+            session_closed_callback: None,
+            connection_status_callback: None,
+            message_queue,
+        };
+        ss
     }
 
     pub fn id(&self) -> u32 {

--- a/lib/src/client/session/session_state.rs
+++ b/lib/src/client/session/session_state.rs
@@ -186,6 +186,7 @@ impl SessionState {
             session_closed_callback: None,
             connection_status_callback: None,
             message_queue: Arc::new(RwLock::new(MessageQueue::new())),
+        }
     }
 
     pub fn new_with_message_queue(
@@ -195,11 +196,7 @@ impl SessionState {
         message_queue: Arc<RwLock<MessageQueue>>,
     ) -> SessionState {
         let id = NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed);
-        {
-            let mq = message_queue.read();
-            debug!("### SessionState new_with_message_queue has id: {}, and messag_queue id: {}", id, mq.mq_id);
-        }
-        let ss = SessionState {
+        SessionState {
             id,
             client_offset: Duration::zero(),
             ignore_clock_skew,
@@ -219,8 +216,7 @@ impl SessionState {
             session_closed_callback: None,
             connection_status_callback: None,
             message_queue,
-        };
-        ss
+        }
     }
 
     pub fn id(&self) -> u32 {


### PR DESCRIPTION
Now when the server connection is lost, the session is able to reconnect and get back the previous subscirptions as it should be. 