### PR TITLE
feat(subscription): Allow to detect when all data_value event are sent

### DIFF
--- a/lib/src/client/session/services/subscriptions/mod.rs
+++ b/lib/src/client/session/services/subscriptions/mod.rs
@@ -42,6 +42,9 @@ pub trait OnSubscriptionNotification: Send + Sync {
 
     /// Called for each received event.
     fn on_event(&mut self, _event_fields: Option<Vec<Variant>>, _item: &MonitoredItem) {}
+
+    /// Called after others events, when message is fully handled.
+    fn on_packet_handled(&mut self) {}
 }
 
 /// A convenient wrapper around a set of callback functions that implements [OnSubscriptionNotification]
@@ -447,5 +450,7 @@ impl Subscription {
                 }
             }
         }
+
+        self.callback.on_packet_handled();
     }
 }


### PR DESCRIPTION
This allows to write code like that :
```rust
struct NotificationHandler {
    buffer: Chunk,
    sender: Sender,
}

impl OnSubscriptionNotification for NotificationHandler {
    fn on_data_value(&mut self, val: DataValue, item: &MonitoredItem) {
        let Some(value) = val.value else {
            return;
        };

        self.buffer.add_point(item.item_to_monitor().node_id, value);
    }

    fn on_packet_handled(&mut self) {
        self.sender.send(std::mem::take(&mut self.buffer));
    }
}
```

I didn't add the entry in `SubscriptionCallbacks`, because the main purpose of this “packet handled” event is to flush something, which require shared state (which is hard in different `FnMut`), and also because it would be a breaking change.