### PR TITLE
Replace Openssl by a pure rust libraries (from RustCrypto project)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,7 +355,18 @@ checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
  "aesni",
- "cipher",
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cipher 0.4.4",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -365,8 +376,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
 dependencies = [
  "aead",
- "aes",
- "cipher",
+ "aes 0.6.0",
+ "cipher 0.2.5",
  "ctr",
  "ghash",
  "subtle",
@@ -378,7 +389,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
  "opaque-debug",
 ]
 
@@ -388,7 +399,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
  "opaque-debug",
 ]
 
@@ -517,6 +528,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +559,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -625,6 +651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher 0.4.4",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +706,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +723,12 @@ checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -694,10 +745,10 @@ dependencies = [
  "aes-gcm",
  "base64 0.13.1",
  "hkdf",
- "hmac",
+ "hmac 0.10.1",
  "percent-encoding 2.3.1",
  "rand 0.8.5",
- "sha2",
+ "sha2 0.9.9",
  "time 0.1.45",
 ]
 
@@ -845,7 +896,31 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
 dependencies = [
- "cipher",
+ "cipher 0.2.5",
+]
+
+[[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "der_derive",
+ "flagset",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
+dependencies = [
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -914,7 +989,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1047,6 +1124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "flagset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1064,7 +1147,7 @@ checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1344,7 +1427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
 dependencies = [
  "digest 0.9.0",
- "hmac",
+ "hmac 0.10.1",
 ]
 
 [[package]]
@@ -1355,6 +1438,15 @@ checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1479,6 +1571,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1670,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin 0.5.2",
+]
 
 [[package]]
 name = "lazycell"
@@ -1580,6 +1685,12 @@ name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "linked-hash-map"
@@ -1828,10 +1939,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec 1.13.2",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg 1.2.0",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1840,6 +1988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg 1.2.0",
+ "libm",
 ]
 
 [[package]]
@@ -1879,36 +2028,43 @@ version = "0.13.0"
 dependencies = [
  "actix-files",
  "actix-web 4.5.1",
+ "aes 0.8.4",
  "arbitrary",
  "arc-swap",
  "base64 0.21.7",
  "bitflags 2.5.0",
  "byteorder",
  "bytes 1.6.0",
+ "cbc",
  "chrono",
+ "const-oid",
  "derivative",
  "env_logger",
  "foreign-types",
  "futures 0.3.30",
  "gethostname",
+ "hmac 0.12.1",
  "lazy_static",
  "libc",
  "log 0.4.21",
  "opcua",
- "openssl",
- "openssl-sys",
  "parking_lot 0.12.1",
+ "rand 0.8.5",
  "regex",
+ "rsa",
  "rumqttc",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_yaml",
+ "sha1 0.10.6",
+ "sha2 0.10.8",
  "tempdir",
  "tokio 1.36.0",
  "tokio-util",
  "url 1.7.2",
  "uuid 1.8.0",
+ "x509-cert",
 ]
 
 [[package]]
@@ -2013,58 +2169,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
-dependencies = [
- "bitflags 2.5.0",
- "cfg-if 1.0.0",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2 1.0.79",
- "quote 1.0.35",
- "syn 2.0.55",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-src"
-version = "300.2.3+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -2163,6 +2271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2191,6 +2308,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2548,9 +2686,31 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.12",
  "libc",
- "spin",
+ "spin 0.9.8",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha1 0.10.6",
+ "sha2 0.10.8",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2837,12 +2997,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2892,11 +3073,27 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api 0.4.11",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3070,6 +3267,27 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "tokio"
@@ -3596,12 +3814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e8257fbc510f0a46eb602c10215901938b5c2a7d5e70fc11483b1d3c9b5b18c"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,6 +4107,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "sha1 0.10.6",
+ "signature",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,6 +4134,26 @@ name = "zerocopy-derive"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2 1.0.79",
+ "quote 1.0.35",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2 1.0.79",
  "quote 1.0.35",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -23,7 +23,7 @@ appveyor = { repository = "locka99/opcua" }
 default = ["server", "client"]
 all = ["server", "client", "console-logging", "http"]
 # This is for CI/CD testing on platforms with unresolved OpenSSL deps, don't use otherwise.
-test-vendored-openssl = ["all", "vendored-openssl"]
+#test-vendored-openssl = ["all", "vendored-openssl"]
 # Server default settings
 server = ["generated-address-space", "discovery-server-registration"]
 # Client default settings
@@ -36,8 +36,8 @@ generated-address-space = []
 # Allows a server to register itself with a local discovery server. It does so by becoming a client to the LDS,
 # which brings in a dependency to opcua-client. Omitting the feature saves some memory.
 discovery-server-registration = ["client"]
-# OpenSSL can be compiled and statically linked to with this feature
-vendored-openssl = ["openssl/vendored"]
+# OpenSSL can be compiled and statically linked to with this feature#
+#vendored-openssl = ["openssl/vendored"]
 # Servers might want to show a web server with metric / diagnostic info
 http = ["actix-files", "actix-web"]
 
@@ -62,8 +62,17 @@ derivative = "2.2"
 byteorder = "1.4"
 base64 = "0.21"
 uuid = { version = "1.2", features = ["v4"] }
-openssl = "0.10"
-openssl-sys = "0.9"
+
+hmac = "0.12.1"
+sha2 = {version = "0.10.8", features = ["oid"]}
+sha1 = {version = "0.10.6", features = ["oid"]}
+cbc  = "0.1.2"
+aes  = "0.8.4"
+rsa = {version = "0.9.6", features = ["sha2","sha1","pem"]}
+rand = "0.8.5"
+x509-cert = {version="0.2.5",features=["builder","hazmat"]}
+const-oid = {version="0.9.3",features=["db"]}
+
 gethostname = "0.4"
 libc = "0.2"
 foreign-types = "0.3"

--- a/lib/src/core/tests/mod.rs
+++ b/lib/src/core/tests/mod.rs
@@ -146,7 +146,7 @@ fn make_test_cert(key_size: u32) -> (X509, PrivateKey) {
             "foo2".to_string(),
             APPLICATION_HOSTNAME.to_string(),
             "foo3".to_string(),
-        ],
+        ].into(),
         certificate_duration_days: 60,
     };
     let cert = X509::cert_and_pkey(&args);

--- a/lib/src/crypto/pkey.rs
+++ b/lib/src/crypto/pkey.rs
@@ -9,7 +9,18 @@ use std::{
     result::Result,
 };
 
-use openssl::{hash, pkey, rsa, sign};
+use rand;
+use rsa::pkcs1;
+use rsa::pkcs1v15;
+use rsa::pkcs8;
+use rsa::pss;
+use rsa::signature::{RandomizedSigner, SignatureEncoding, Verifier};
+use rsa::{Oaep, Pkcs1v15Encrypt, RsaPrivateKey, RsaPublicKey};
+use sha1;
+use sha2;
+
+use x509_cert;
+use x509_cert::spki::SubjectPublicKeyInfoOwned;
 
 use crate::types::status_code::StatusCode;
 
@@ -18,19 +29,6 @@ pub enum RsaPadding {
     Pkcs1,
     OaepSha1,
     OaepSha256,
-    Pkcs1Pss,
-}
-
-impl Into<rsa::Padding> for RsaPadding {
-    fn into(self) -> rsa::Padding {
-        match self {
-            RsaPadding::Pkcs1 => rsa::Padding::PKCS1,
-            RsaPadding::OaepSha1 => rsa::Padding::PKCS1_OAEP,
-            RsaPadding::Pkcs1Pss => rsa::Padding::PKCS1_PSS,
-            // Note: This is the right padding but not the right hash and must be handled by special case in the code
-            RsaPadding::OaepSha256 => rsa::Padding::PKCS1_OAEP,
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -44,16 +42,34 @@ impl fmt::Display for PKeyError {
 
 impl std::error::Error for PKeyError {}
 
-/// This is a wrapper around an `OpenSSL` asymmetric key pair. Since openssl 0.10, the PKey is either
+impl From<pkcs8::Error> for PKeyError {
+    fn from(_err: pkcs8::Error) -> Self {
+        PKeyError
+    }
+}
+
+impl From<pkcs1::Error> for PKeyError {
+    fn from(_err: pkcs1::Error) -> Self {
+        PKeyError
+    }
+}
+
+impl From<rsa::Error> for PKeyError {
+    fn from(_err: rsa::Error) -> Self {
+        PKeyError
+    }
+}
+
+/// This is a wrapper around an asymmetric key pair. Since the PKey is either
 /// a public or private key so we have to differentiate that as well.
 pub struct PKey<T> {
-    pub(crate) value: pkey::PKey<T>,
+    pub(crate) value: T,
 }
 
 /// A public key
-pub type PublicKey = PKey<pkey::Public>;
+pub type PublicKey = PKey<RsaPublicKey>;
 // A private key
-pub type PrivateKey = PKey<pkey::Private>;
+pub type PrivateKey = PKey<RsaPrivateKey>;
 
 impl<T> Debug for PKey<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -64,12 +80,13 @@ impl<T> Debug for PKey<T> {
 }
 
 pub trait KeySize {
-    fn bit_length(&self) -> usize;
-
-    fn size(&self) -> usize {
-        self.bit_length() / 8
+    fn bit_length(&self) -> usize {
+        self.size() * 8
     }
 
+    fn size(&self) -> usize;
+
+    //the following functions is only used in secure channel
     fn calculate_cipher_text_size(&self, data_size: usize, padding: RsaPadding) -> usize {
         let plain_text_block_size = self.plain_text_block_size(padding);
         let block_count = if data_size % plain_text_block_size == 0 {
@@ -77,18 +94,22 @@ pub trait KeySize {
         } else {
             (data_size / plain_text_block_size) + 1
         };
+
         block_count * self.cipher_text_block_size()
     }
 
     fn plain_text_block_size(&self, padding: RsaPadding) -> usize {
-        // flen must not be more than RSA_size(rsa) - 11 for the PKCS #1 v1.5 based padding modes,
-        // not more than RSA_size(rsa) - 42 for RSA_PKCS1_OAEP_PADDING and exactly RSA_size(rsa)
-        // for RSA_NO_PADDING.
+        // the maximum plain text size block is given by
+        // for pkcs#1 v1.5 , keyLength - 11
+        // for oaep  keyLength -2 hsize -2
+        // where all sizes are in bytes
+        // sha256 size is 256bits => 32 bytes,
+        //sha1 size is 160bits => 20 bytes
+
         match padding {
             RsaPadding::Pkcs1 => self.size() - 11,
             RsaPadding::OaepSha1 => self.size() - 42,
             RsaPadding::OaepSha256 => self.size() - 66,
-            _ => panic!("Unsupported padding"),
         }
     }
 
@@ -99,103 +120,131 @@ pub trait KeySize {
 
 impl KeySize for PrivateKey {
     /// Length in bits
-    fn bit_length(&self) -> usize {
-        self.value.bits() as usize
+    fn size(&self) -> usize {
+        use rsa::traits::PublicKeyParts;
+        self.value.size()
     }
 }
 
 impl PrivateKey {
     pub fn new(bit_length: u32) -> PrivateKey {
-        PKey {
-            value: {
-                let rsa = rsa::Rsa::generate(bit_length).unwrap();
-                pkey::PKey::from_rsa(rsa).unwrap()
-            },
+        let mut rng = rand::thread_rng();
+
+        let key = RsaPrivateKey::new(&mut rng, bit_length as usize).unwrap();
+        PKey { value: key }
+    }
+
+    pub fn read_pem_file(path: &std::path::Path) -> Result<PrivateKey, PKeyError> {
+        use pkcs8::DecodePrivateKey;
+        use rsa::pkcs1::DecodeRsaPrivateKey;
+
+        let r = RsaPrivateKey::read_pkcs8_pem_file(path);
+        match r {
+            Err(_) => {
+                let val = RsaPrivateKey::read_pkcs1_pem_file(path)?;
+                Ok(PKey { value: val })
+            }
+            Ok(val) => Ok(PKey { value: val }),
         }
     }
 
-    pub fn wrap_private_key(pkey: pkey::PKey<pkey::Private>) -> PrivateKey {
-        PrivateKey { value: pkey }
-    }
+    pub fn from_pem(bytes: &[u8]) -> Result<PrivateKey, PKeyError> {
+        use pkcs8::DecodePrivateKey;
+        use rsa::pkcs1::DecodeRsaPrivateKey;
 
-    pub fn from_pem(pem: &[u8]) -> Result<PrivateKey, PKeyError> {
-        pkey::PKey::private_key_from_pem(pem)
-            .map(|value| PKey { value })
-            .map_err(|_| {
-                error!("Cannot produce a private key from the data supplied");
-                PKeyError
-            })
-    }
-
-    pub fn private_key_to_pem(&self) -> Result<Vec<u8>, PKeyError> {
-        self.value.private_key_to_pem_pkcs8().map_err(|_| {
-            error!("Cannot turn private key to PEM");
-            PKeyError
-        })
-    }
-
-    /// Creates a message digest from the specified block of data and then signs it to return a signature
-    fn sign(
-        &self,
-        message_digest: hash::MessageDigest,
-        data: &[u8],
-        signature: &mut [u8],
-        padding: RsaPadding,
-    ) -> Result<usize, StatusCode> {
-        trace!("RSA signing");
-        if let Ok(mut signer) = sign::Signer::new(message_digest, &self.value) {
-            let _ = signer.set_rsa_padding(padding.into());
-            let _ = signer.set_rsa_pss_saltlen(sign::RsaPssSaltlen::DIGEST_LENGTH);
-            if signer.update(data).is_ok() {
-                return signer
-                    .sign_to_vec()
-                    .map(|result| {
-                        trace!(
-                            "Signature result, len {} = {:?}, copying to signature len {}",
-                            result.len(),
-                            result,
-                            signature.len()
-                        );
-                        signature.copy_from_slice(&result);
-                        result.len()
-                    })
-                    .map_err(|err| {
-                        debug!("Cannot sign data - error = {:?}", err);
-                        StatusCode::BadUnexpectedError
-                    });
+        let converted = std::str::from_utf8(bytes);
+        match converted {
+            Err(_) => Err(PKeyError),
+            Ok(pem) => {
+                let r = RsaPrivateKey::from_pkcs8_pem(pem);
+                match r {
+                    Err(_) => {
+                        let val = RsaPrivateKey::from_pkcs1_pem(pem)?;
+                        Ok(PKey { value: val })
+                    }
+                    Ok(val) => Ok(PKey { value: val }),
+                }
             }
         }
-        Err(StatusCode::BadUnexpectedError)
+    }
+
+    pub fn to_der(&self) -> pkcs8::Result<pkcs8::SecretDocument> {
+        use pkcs8::EncodePrivateKey;
+
+        self.value.to_pkcs8_der()
+    }
+
+    pub fn public_key_to_info(&self) -> x509_cert::spki::Result<SubjectPublicKeyInfoOwned> {
+        use rsa::pkcs8::EncodePublicKey;
+        SubjectPublicKeyInfoOwned::try_from(
+            self.value
+                .to_public_key()
+                .to_public_key_der()
+                .unwrap()
+                .as_bytes(),
+        )
+    }
+
+    pub fn to_public_key(&self) -> PublicKey {
+        PublicKey {
+            value: self.value.to_public_key(),
+        }
     }
 
     /// Signs the data using RSA-SHA1
     pub fn sign_sha1(&self, data: &[u8], signature: &mut [u8]) -> Result<usize, StatusCode> {
-        self.sign(
-            hash::MessageDigest::sha1(),
-            data,
-            signature,
-            RsaPadding::Pkcs1,
-        )
+        let mut rng = rand::thread_rng();
+        let signing_key = pkcs1v15::SigningKey::<sha1::Sha1>::new(self.value.clone());
+        match signing_key.try_sign_with_rng(&mut rng, data) {
+            Err(_) => Err(StatusCode::BadUnexpectedError),
+            Ok(signed) => {
+                let val = signed.to_vec();
+                signature.copy_from_slice(&val);
+                Ok(val.len())
+            }
+        }
     }
 
     /// Signs the data using RSA-SHA256
     pub fn sign_sha256(&self, data: &[u8], signature: &mut [u8]) -> Result<usize, StatusCode> {
-        self.sign(
-            hash::MessageDigest::sha256(),
-            data,
-            signature,
-            RsaPadding::Pkcs1,
-        )
+        let mut rng = rand::thread_rng();
+        let signing_key = pkcs1v15::SigningKey::<sha2::Sha256>::new(self.value.clone());
+        match signing_key.try_sign_with_rng(&mut rng, data) {
+            Err(_) => Err(StatusCode::BadUnexpectedError),
+            Ok(signed) => {
+                let val = signed.to_vec();
+                signature.copy_from_slice(&val);
+                Ok(val.len())
+            }
+        }
     }
 
     /// Signs the data using RSA-SHA256-PSS
     pub fn sign_sha256_pss(&self, data: &[u8], signature: &mut [u8]) -> Result<usize, StatusCode> {
-        self.sign(
-            hash::MessageDigest::sha256(),
-            data,
-            signature,
-            RsaPadding::Pkcs1Pss,
-        )
+        let mut rng = rand::thread_rng();
+        let signing_key = pss::BlindedSigningKey::<sha2::Sha256>::new(self.value.clone());
+        match signing_key.try_sign_with_rng(&mut rng, data) {
+            Err(_) => Err(StatusCode::BadUnexpectedError),
+            Ok(signed) => {
+                let val = signed.to_vec();
+                signature.copy_from_slice(&val);
+                Ok(val.len())
+            }
+        }
+    }
+
+    fn pkcs1_decrypt(&self, src: &[u8]) -> rsa::errors::Result<Vec<u8>> {
+        self.value.decrypt(Pkcs1v15Encrypt, src)
+    }
+
+    fn oaepsha1_decrypt(&self, src: &[u8]) -> rsa::errors::Result<Vec<u8>> {
+        let padding = Oaep::new::<sha1::Sha1>();
+        self.value.decrypt(padding, src)
+    }
+
+    fn oaepsha2_decrypt(&self, src: &[u8]) -> rsa::errors::Result<Vec<u8>> {
+        let padding = Oaep::new::<sha2::Sha256>();
+        self.value.decrypt(padding, src)
     }
 
     /// Decrypts data in src to dst using the specified padding and returning the size of the decrypted
@@ -206,11 +255,7 @@ impl PrivateKey {
         dst: &mut [u8],
         padding: RsaPadding,
     ) -> Result<usize, PKeyError> {
-        // decrypt data using our private key
         let cipher_text_block_size = self.cipher_text_block_size();
-        let rsa = self.value.rsa().unwrap();
-        let is_oaep_sha256 = padding == RsaPadding::OaepSha256;
-        let rsa_padding: rsa::Padding = padding.into();
 
         // Decrypt the data
         let mut src_idx = 0;
@@ -218,21 +263,29 @@ impl PrivateKey {
 
         let src_len = src.len();
         while src_idx < src_len {
+            let src_end_index = src_idx + cipher_text_block_size;
+
             // Decrypt and advance
             dst_idx += {
-                let src = &src[src_idx..(src_idx + cipher_text_block_size)];
+                let src = &src[src_idx..src_end_index];
                 let dst = &mut dst[dst_idx..(dst_idx + cipher_text_block_size)];
 
-                if is_oaep_sha256 {
-                    oaep_sha256::decrypt(&rsa, src, dst)
+                let decrypted;
+                match padding {
+                    RsaPadding::OaepSha256 => decrypted = self.oaepsha2_decrypt(src)?,
+                    RsaPadding::Pkcs1 => decrypted = self.pkcs1_decrypt(src)?,
+                    RsaPadding::OaepSha1 => decrypted = self.oaepsha1_decrypt(src)?,
+                }
+
+                let size = decrypted.len();
+                if size == dst.len() {
+                    dst.copy_from_slice(&decrypted);
                 } else {
-                    rsa.private_decrypt(src, dst, rsa_padding)
-                }.map_err(|err| {
-                    error!("Decryption failed for key size {}, src idx {}, dst idx {}, padding {:?}, error - {:?}", cipher_text_block_size, src_idx, dst_idx, padding, err);
-                    PKeyError
-                })?
+                    dst[0..size].copy_from_slice(&decrypted);
+                }
+                size
             };
-            src_idx += cipher_text_block_size;
+            src_idx = src_end_index;
         }
         Ok(dst_idx)
     }
@@ -240,76 +293,81 @@ impl PrivateKey {
 
 impl KeySize for PublicKey {
     /// Length in bits
-    fn bit_length(&self) -> usize {
-        self.value.bits() as usize
+    fn size(&self) -> usize {
+        use rsa::traits::PublicKeyParts;
+        self.value.size()
     }
 }
 
 impl PublicKey {
-    pub fn wrap_public_key(pkey: pkey::PKey<pkey::Public>) -> PublicKey {
-        PublicKey { value: pkey }
-    }
-
-    /// Verifies that the signature matches the hash / signing key of the supplied data
-    fn verify(
-        &self,
-        message_digest: hash::MessageDigest,
-        data: &[u8],
-        signature: &[u8],
-        padding: RsaPadding,
-    ) -> Result<bool, StatusCode> {
-        trace!(
-            "RSA verifying, against signature {:?}, len {}",
-            signature,
-            signature.len()
-        );
-        if let Ok(mut verifier) = sign::Verifier::new(message_digest, &self.value) {
-            let _ = verifier.set_rsa_padding(padding.into());
-            let _ = verifier.set_rsa_pss_saltlen(sign::RsaPssSaltlen::DIGEST_LENGTH);
-            if verifier.update(data).is_ok() {
-                return verifier
-                    .verify(signature)
-                    .map(|result| {
-                        trace!("Key verified = {:?}", result);
-                        result
-                    })
-                    .map_err(|err| {
-                        debug!("Cannot verify key - error = {:?}", err);
-                        StatusCode::BadUnexpectedError
-                    });
-            }
-        }
-        Err(StatusCode::BadUnexpectedError)
-    }
-
     /// Verifies the data using RSA-SHA1
     pub fn verify_sha1(&self, data: &[u8], signature: &[u8]) -> Result<bool, StatusCode> {
-        self.verify(
-            hash::MessageDigest::sha1(),
-            data,
-            signature,
-            RsaPadding::Pkcs1,
-        )
+        let verifying_key = pkcs1v15::VerifyingKey::<sha1::Sha1>::new(self.value.clone());
+        let r = pkcs1v15::Signature::try_from(signature);
+        match r {
+            Err(_) => Err(StatusCode::BadUnexpectedError),
+            Ok(val) => match verifying_key.verify(data, &val) {
+                Err(_) => Ok(false),
+                _ => Ok(true),
+            },
+        }
     }
 
     /// Verifies the data using RSA-SHA256
     pub fn verify_sha256(&self, data: &[u8], signature: &[u8]) -> Result<bool, StatusCode> {
-        self.verify(
-            hash::MessageDigest::sha256(),
-            data,
-            signature,
-            RsaPadding::Pkcs1,
-        )
+        let verifying_key = pkcs1v15::VerifyingKey::<sha2::Sha256>::new(self.value.clone());
+        let r = pkcs1v15::Signature::try_from(signature);
+        match r {
+            Err(_) => Err(StatusCode::BadUnexpectedError),
+            Ok(val) => match verifying_key.verify(data, &val) {
+                Err(_) => Ok(false),
+                _ => Ok(true),
+            },
+        }
     }
 
     /// Verifies the data using RSA-SHA256-PSS
     pub fn verify_sha256_pss(&self, data: &[u8], signature: &[u8]) -> Result<bool, StatusCode> {
-        self.verify(
-            hash::MessageDigest::sha256(),
-            data,
-            signature,
-            RsaPadding::Pkcs1Pss,
-        )
+        let verifying_key = pss::VerifyingKey::<sha2::Sha256>::new(self.value.clone());
+        let r = pss::Signature::try_from(signature);
+        match r {
+            Err(_) => Err(StatusCode::BadUnexpectedError),
+            Ok(val) => match verifying_key.verify(data, &val) {
+                Err(_) => Ok(false),
+                _ => Ok(true),
+            },
+        }
+    }
+
+    fn pkcs1_encrypt(&self, src: &[u8]) -> rsa::errors::Result<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+        self.value.encrypt(&mut rng, Pkcs1v15Encrypt, src)
+    }
+
+    fn oaepsha1_encrypt(&self, src: &[u8]) -> rsa::errors::Result<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+        let padding = Oaep::new::<sha1::Sha1>();
+        self.value.encrypt(&mut rng, padding, src)
+    }
+
+    fn oaepsha2_encrypt(&self, src: &[u8]) -> rsa::errors::Result<Vec<u8>> {
+        let mut rng = rand::thread_rng();
+        let padding = Oaep::new::<sha2::Sha256>();
+        self.value.encrypt(&mut rng, padding, src)
+    }
+
+    fn encrypt_data_chunk(&self, src: &[u8], padding: RsaPadding) -> Result<Vec<u8>, PKeyError> {
+        let r: rsa::errors::Result<Vec<u8>>;
+        match padding {
+            RsaPadding::OaepSha256 => r = self.oaepsha2_encrypt(src),
+            RsaPadding::Pkcs1 => r = self.pkcs1_encrypt(src),
+            RsaPadding::OaepSha1 => r = self.oaepsha1_encrypt(src),
+        }
+
+        match r {
+            Err(_) => Err(PKeyError),
+            Ok(val) => Ok(val),
+        }
     }
 
     /// Encrypts data from src to dst using the specified padding and returns the size of encrypted
@@ -323,14 +381,6 @@ impl PublicKey {
         let cipher_text_block_size = self.cipher_text_block_size();
         let plain_text_block_size = self.plain_text_block_size(padding);
 
-        // For reference:
-        //
-        // https://www.openssl.org/docs/man1.0.2/crypto/RSA_public_encrypt.html
-        let rsa = self.value.rsa().unwrap();
-        let is_oaep_sha256 = padding == RsaPadding::OaepSha256;
-        let padding: rsa::Padding = padding.into();
-
-        // Encrypt the data in chunks no larger than the key size less padding
         let mut src_idx = 0;
         let mut dst_idx = 0;
 
@@ -344,163 +394,21 @@ impl PublicKey {
                 plain_text_block_size
             };
 
+            let src_end_index = src_idx + bytes_to_encrypt;
+
             // Encrypt data, advance dst index by number of bytes after encrypted
             dst_idx += {
-                let src = &src[src_idx..(src_idx + bytes_to_encrypt)];
-                let dst = &mut dst[dst_idx..(dst_idx + cipher_text_block_size)];
+                let src = &src[src_idx..src_end_index];
 
-                if is_oaep_sha256 {
-                    oaep_sha256::encrypt(&rsa, src, dst)
-                } else {
-                    rsa.public_encrypt(src, dst, padding)
-                }.map_err(|err| {
-                    error!("Encryption failed for bytes_to_encrypt {}, src len {}, src_idx {}, dst len {}, dst_idx {}, cipher_text_block_size {}, plain_text_block_size {}, error - {:?}",
-                           bytes_to_encrypt, src.len(), src_idx, dst.len(), dst_idx, cipher_text_block_size, plain_text_block_size, err);
-                    PKeyError
-                })?
+                let encrypted = self.encrypt_data_chunk(src, padding)?;
+                dst[dst_idx..(dst_idx + cipher_text_block_size)].copy_from_slice(&encrypted);
+                encrypted.len()
             };
 
             // Src advances by bytes to encrypt
-            src_idx += bytes_to_encrypt;
+            src_idx = src_end_index;
         }
 
         Ok(dst_idx)
-    }
-}
-
-/// This module contains a bunch of nasty stuff to implement OAEP-SHA256 since there are no helpers in OpenSSL to do it
-///
-/// https://stackoverflow.com/questions/17784022/how-to-encrypt-data-using-rsa-with-sha-256-as-hash-function-and-mgf1-as-mask-ge
-mod oaep_sha256 {
-    use foreign_types::ForeignType;
-    use libc::*;
-    use openssl::{
-        error,
-        pkey::{Private, Public},
-        rsa::{self, Rsa},
-    };
-    use openssl_sys::*;
-    use std::ptr;
-
-    // This sets up the context for encrypting / decrypting with OAEP + SHA256
-    unsafe fn set_evp_ctrl_oaep_sha256(ctx: *mut EVP_PKEY_CTX) {
-        EVP_PKEY_CTX_set_rsa_padding(ctx, rsa::Padding::PKCS1_OAEP.as_raw());
-        let md = EVP_sha256() as *mut EVP_MD;
-        EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md);
-        // This is a hack because OpenSSL crate doesn't expose this const or a wrapper fn
-        const EVP_PKEY_CTRL_RSA_OAEP_MD: c_int = EVP_PKEY_ALG_CTRL + 9;
-        EVP_PKEY_CTX_ctrl(
-            ctx,
-            EVP_PKEY_RSA,
-            EVP_PKEY_OP_TYPE_CRYPT,
-            EVP_PKEY_CTRL_RSA_OAEP_MD,
-            0,
-            md as *mut c_void,
-        );
-    }
-
-    /// Special case implementation uses OAEP with SHA256
-    pub fn decrypt(
-        pkey: &Rsa<Private>,
-        from: &[u8],
-        to: &mut [u8],
-    ) -> Result<usize, error::ErrorStack> {
-        let result;
-        unsafe {
-            let priv_key = EVP_PKEY_new();
-            if !priv_key.is_null() {
-                EVP_PKEY_set1_RSA(priv_key, pkey.as_ptr());
-                let ctx = EVP_PKEY_CTX_new(priv_key, ptr::null_mut());
-                EVP_PKEY_free(priv_key);
-
-                if !ctx.is_null() {
-                    let _ret = EVP_PKEY_decrypt_init(ctx);
-                    set_evp_ctrl_oaep_sha256(ctx);
-
-                    let mut out_len: size_t = to.len();
-                    let ret = EVP_PKEY_decrypt(
-                        ctx,
-                        to.as_mut_ptr(),
-                        &mut out_len,
-                        from.as_ptr(),
-                        from.len(),
-                    );
-                    if ret > 0 && out_len > 0 {
-                        result = Ok(out_len as usize);
-                    } else {
-                        trace!(
-                            "oaep_sha256::decrypt EVP_PKEY_decrypt, ret = {}, out_len = {}",
-                            ret,
-                            out_len
-                        );
-                        result = Err(error::ErrorStack::get());
-                    }
-                    EVP_PKEY_CTX_free(ctx);
-                } else {
-                    trace!("oaep_sha256::decrypt EVP_PKEY_CTX_new");
-                    result = Err(error::ErrorStack::get());
-                }
-            } else {
-                trace!(
-                    "oaep_sha256::decrypt EVP_PKEY_new failed, err {}",
-                    ERR_get_error()
-                );
-                result = Err(error::ErrorStack::get());
-            }
-        }
-
-        result
-    }
-
-    /// Special case implementation uses OAEP with SHA256
-    pub fn encrypt(
-        pkey: &Rsa<Public>,
-        from: &[u8],
-        to: &mut [u8],
-    ) -> Result<usize, error::ErrorStack> {
-        let result;
-        unsafe {
-            let pub_key = EVP_PKEY_new();
-            if !pub_key.is_null() {
-                EVP_PKEY_set1_RSA(pub_key, pkey.as_ptr());
-                let ctx = EVP_PKEY_CTX_new(pub_key, ptr::null_mut());
-                EVP_PKEY_free(pub_key);
-
-                if !ctx.is_null() {
-                    let _ret = EVP_PKEY_encrypt_init(ctx);
-                    set_evp_ctrl_oaep_sha256(ctx);
-
-                    let mut out_len: size_t = to.len();
-                    let ret = EVP_PKEY_encrypt(
-                        ctx,
-                        to.as_mut_ptr(),
-                        &mut out_len,
-                        from.as_ptr(),
-                        from.len(),
-                    );
-                    if ret > 0 && out_len > 0 {
-                        result = Ok(out_len as usize);
-                    } else {
-                        trace!(
-                            "oaep_sha256::encrypt EVP_PKEY_encrypt, ret = {}, out_len = {}",
-                            ret,
-                            out_len
-                        );
-                        result = Err(error::ErrorStack::get());
-                    }
-                    EVP_PKEY_CTX_free(ctx);
-                } else {
-                    trace!("oaep_sha256::encrypt EVP_PKEY_CTX_new");
-                    result = Err(error::ErrorStack::get());
-                }
-            } else {
-                trace!(
-                    "oaep_sha256::encrypt EVP_PKEY_new failed, err {}",
-                    ERR_get_error()
-                );
-                result = Err(error::ErrorStack::get());
-            }
-        }
-        result
     }
 }

--- a/lib/src/crypto/random.rs
+++ b/lib/src/crypto/random.rs
@@ -4,13 +4,16 @@
 
 //! Module contains functions for creating cryptographically strong random bytes.
 
-use openssl::rand;
-
 use crate::types::byte_string::ByteString;
+
+use rand;
 
 /// Fills the slice with cryptographically strong pseudo-random bytes
 pub fn bytes(bytes: &mut [u8]) {
-    let _ = rand::rand_bytes(bytes);
+    use rand::RngCore;
+
+    let mut rng = rand::thread_rng();
+    rng.fill_bytes(bytes);
 }
 
 /// Create a byte string with a number of random characters. Can be used to create a nonce or

--- a/lib/src/crypto/security_policy.rs
+++ b/lib/src/crypto/security_policy.rs
@@ -7,8 +7,6 @@
 use std::fmt;
 use std::str::FromStr;
 
-use openssl::hash as openssl_hash;
-
 use crate::types::{constants, status_code::StatusCode, ByteString};
 
 use super::{
@@ -424,18 +422,17 @@ impl SecurityPolicy {
     /// from a secret and seed specified by the parameters.
     fn prf(&self, secret: &[u8], seed: &[u8], length: usize, offset: usize) -> Vec<u8> {
         // P_SHA1 or P_SHA256
-        let message_digest = match self {
+        let result = match self {
             SecurityPolicy::Basic128Rsa15 | SecurityPolicy::Basic256 => {
-                openssl_hash::MessageDigest::sha1()
+                hash::p_sha1(secret, seed, offset + length)
             }
             SecurityPolicy::Basic256Sha256
             | SecurityPolicy::Aes128Sha256RsaOaep
-            | SecurityPolicy::Aes256Sha256RsaPss => openssl_hash::MessageDigest::sha256(),
+            | SecurityPolicy::Aes256Sha256RsaPss => hash::p_sha256(secret, seed, offset + length),
             _ => {
                 panic!("Invalid policy");
             }
         };
-        let result = hash::p_sha(message_digest, secret, seed, offset + length);
         result[offset..(offset + length)].to_vec()
     }
 

--- a/lib/src/crypto/tests/crypto.rs
+++ b/lib/src/crypto/tests/crypto.rs
@@ -13,7 +13,7 @@ use crate::{
             APPLICATION_URI,
         },
         user_identity::{legacy_password_decrypt, legacy_password_encrypt},
-        x509::{X509Data, X509},
+        x509::{AlternateNames, X509Data, X509},
         SecurityPolicy, SHA1_SIZE, SHA256_SIZE,
     },
     from_hex,
@@ -91,7 +91,7 @@ fn create_own_cert_in_pki() {
         organizational_unit: "x.org ops".to_string(),
         country: "EN".to_string(),
         state: "London".to_string(),
-        alt_host_names: vec!["host1".to_string(), "host2".to_string()],
+        alt_host_names: vec!["host1".to_string(), "host2".to_string()].into(),
         certificate_duration_days: 60,
     };
 

--- a/lib/src/crypto/tests/mod.rs
+++ b/lib/src/crypto/tests/mod.rs
@@ -5,7 +5,7 @@ use crate::types::*;
 use crate::crypto::{
     certificate_store::*,
     pkey::PrivateKey,
-    x509::{X509Data, X509},
+    x509::{AlternateNames, X509Data, X509},
 };
 
 const APPLICATION_URI: &str = "urn:testapplication";
@@ -32,7 +32,8 @@ fn make_test_cert(key_size: u32) -> (X509, PrivateKey) {
             "foo2".to_string(),
             APPLICATION_HOSTNAME.to_string(),
             "foo3".to_string(),
-        ],
+        ]
+        .into(),
         certificate_duration_days: 60,
     };
     let cert = X509::cert_and_pkey(&args);

--- a/lib/src/types/array.rs
+++ b/lib/src/types/array.rs
@@ -52,8 +52,7 @@ impl Array {
         let dimensions = dimensions.into();
 
         // TODO should also Self::validate_dimensions(values.len(), &dimensions)
-        if Self::validate_array_type_to_values(value_type, &values)
-        {
+        if Self::validate_array_type_to_values(value_type, &values) {
             Ok(Array {
                 value_type,
                 values,

--- a/lib/src/types/tests/mod.rs
+++ b/lib/src/types/tests/mod.rs
@@ -1,8 +1,8 @@
 mod date_time;
 mod encoding;
+mod json;
 mod node_id;
 mod variant;
-mod json;
 
 use std::cmp::PartialEq;
 use std::fmt::Debug;

--- a/samples/demo-server/Cargo.toml
+++ b/samples/demo-server/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Adam Lock <locka99@gmail.com>"]
 edition = "2021"
 
 [features]
-vendored-openssl = ["opcua/vendored-openssl"]
+#vendored-openssl = ["opcua/vendored-openssl"]
 
 [dependencies]
 chrono = "0.4"


### PR DESCRIPTION
Dear Adam,

These changes replace the use of Openssl wrapper by pure Rust libraries issued from the RustCrypto project.
The goal is to facilitate build and deployments 
Note that nothing has changed outside the crypto module (except one into() in a test) , all tests passed