### PR TITLE
refactor: Replace deprecated chrono::Duration::*

### DIFF
--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use chrono::Duration;
+use chrono::{Duration, TimeDelta};
 
 use crate::crypto::{
     aeskey::AesKey,
@@ -227,7 +227,7 @@ impl SecureChannel {
         } else {
             // Check if secure channel 75% close to expiration in which case send a renew
             let renew_lifetime = (self.token_lifetime() * 3) / 4;
-            let renew_lifetime = Duration::milliseconds(renew_lifetime as i64);
+            let renew_lifetime = TimeDelta::try_milliseconds(renew_lifetime as i64).unwrap();
             // Renew the token?
             DateTime::now() - self.token_created_at() > renew_lifetime
         }
@@ -373,7 +373,8 @@ impl SecureChannel {
     /// Test if the token has expired yet
     pub fn token_has_expired(&self) -> bool {
         let token_created_at = self.token_created_at;
-        let token_expires = token_created_at + Duration::seconds(self.token_lifetime as i64);
+        let token_expires =
+            token_created_at + TimeDelta::try_seconds(self.token_lifetime as i64).unwrap();
         DateTime::now().ge(&token_expires)
     }
 

--- a/lib/src/types/date_time.rs
+++ b/lib/src/types/date_time.rs
@@ -12,7 +12,7 @@ use std::{
     str::FromStr,
 };
 
-use chrono::{Duration, SecondsFormat, TimeZone, Timelike, Utc};
+use chrono::{Duration, SecondsFormat, TimeDelta, TimeZone, Timelike, Utc};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::types::encoding::*;
@@ -167,7 +167,7 @@ impl From<i64> for DateTime {
         } else {
             let secs = value / TICKS_PER_SECOND;
             let nanos = (value - secs * TICKS_PER_SECOND) * NANOS_PER_TICK;
-            let duration = Duration::seconds(secs) + Duration::nanoseconds(nanos);
+            let duration = TimeDelta::try_seconds(secs).unwrap() + Duration::nanoseconds(nanos);
             Self::from(Self::epoch_chrono() + duration)
         }
     }
@@ -340,7 +340,7 @@ impl DateTime {
     fn duration_to_ticks(duration: Duration) -> i64 {
         // We can't directly ask for nanos because it will exceed i64,
         // so we have to subtract the total seconds before asking for the nano portion
-        let seconds_part = Duration::seconds(duration.num_seconds());
+        let seconds_part = TimeDelta::try_seconds(duration.num_seconds()).unwrap();
         let seconds = seconds_part.num_seconds();
         let nanos = (duration - seconds_part).num_nanoseconds().unwrap();
         // Put it back together in ticks

--- a/samples/demo-server/src/machine.rs
+++ b/samples/demo-server/src/machine.rs
@@ -8,6 +8,7 @@ use std::sync::{
 };
 
 use chrono;
+use chrono::TimeDelta;
 use rand;
 
 use opcua::server::{events::event::*, prelude::*};
@@ -214,7 +215,7 @@ fn raise_machine_cycled_event(
 ) {
     // Remove old events
     let now = chrono::Utc::now();
-    let happened_before = now - chrono::Duration::minutes(5);
+    let happened_before = now - TimeDelta::try_minutes(5).unwrap();
     purge_events(
         source_machine_id,
         MachineCycledEventType::event_type_id(ns),


### PR DESCRIPTION
with TimeDelta::try_*.unwrap().
Both solutions panic when fed invalid input.