### PR TITLE
build: Update action/checkout from v3 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: cargo build --features test-vendored-openssl
       - name: Run tests
@@ -28,7 +28,7 @@ jobs:
     env:
       VCPKGRS_DYNAMIC: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build
         run: cargo build --features test-vendored-openssl
       - name: Run tests


### PR DESCRIPTION
> in order to get rid of the node.js 16 warning

Eventually this might be better handled by dependabot instead of manual bumps.