### PR TITLE
ci: Regenerate and verify the status codes file

### DIFF
--- a/.github/workflows/ci_verify_clean_status_codes.yml
+++ b/.github/workflows/ci_verify_clean_status_codes.yml
@@ -1,0 +1,19 @@
+name: CI verify cleanly generated status codes
+'on':
+  workflow_call: null
+jobs:
+  status_codes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+        working-directory: tools/schema/
+      - name: Regenerate status codes
+        run: node gen_status_codes
+        working-directory: tools/schema/
+      - name: Format generated code
+        run: rustfmt lib/src/types/status_codes.rs
+      - name: Verify generated code matches committed code
+        run: git status --porcelain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,3 +39,6 @@ jobs:
 
   verify-code-formatting:
     uses: ./.github/workflows/ci_format_code.yml
+
+  verify-clean-status-codes:
+    uses: ./.github/workflows/ci_verify_clean_status_codes.yml

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,5 +3,4 @@ ignore = [
     "server/src/address_space/generated",
     "types/src/node_ids.rs",
     "types/src/service_types",
-    "types/src/status_codes.rs",
 ]


### PR DESCRIPTION
> in order to enforce congruence between it and its source csv.
> 
> Furthermore drop the generated file from rustfmt ignore as it's apparently currently formatted.