### PR TITLE
ci: Regenerate and verify the supported messages file

### DIFF
--- a/.github/workflows/ci_verify_clean_supported_message.yml
+++ b/.github/workflows/ci_verify_clean_supported_message.yml
@@ -1,0 +1,19 @@
+name: CI verify cleanly generated supported message
+'on':
+  workflow_call: null
+jobs:
+  supported_message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+        working-directory: tools/schema/
+      - name: Regenerate supported message
+        run: node gen_supported_message
+        working-directory: tools/schema/
+      - name: Format generated code
+        run: rustfmt lib/src/core/supported_message.rs
+      - name: Verify generated code matches committed code
+        run: git status --porcelain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,5 +37,8 @@ jobs:
   code-coverage:
     uses: ./.github/workflows/ci_code_coverage.yml
 
+  verify-clean-supported-message:
+    uses: ./.github/workflows/ci_verify_clean_supported_message.yml
+
   verify-code-formatting:
     uses: ./.github/workflows/ci_format_code.yml

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 ignore = [
-    "core/src/supported_messsages.rs",
     "server/src/address_space/generated",
     "types/src/node_ids.rs",
     "types/src/service_types",

--- a/tools/schema/gen_supported_message.js
+++ b/tools/schema/gen_supported_message.js
@@ -28,7 +28,7 @@ use crate::types::{
     service_types::*,
 };
 
-pub use crate::server::comms::tcp_types::AcknowledgeMessage;
+pub use crate::core::comms::tcp_types::AcknowledgeMessage;
 
 /// This macro helps avoid tedious repetition as new messages are added
 /// The first form just handles the trailing comma after the last entry to save some pointless


### PR DESCRIPTION
> in order to enforce congruence between it and its source list.
> 
> Furthermore drop the generated file from rustfmt ignore
> as it's apparently currently formatted.