### PR TITLE
ci: Regenerate and verify the address space files

### DIFF
--- a/.github/workflows/ci_verify_clean_address_space.yml
+++ b/.github/workflows/ci_verify_clean_address_space.yml
@@ -1,0 +1,20 @@
+name: CI verify cleanly generated address space
+'on':
+  workflow_call: null
+jobs:
+  address_space:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+        working-directory: tools/schema/
+      - name: Regenerate address space
+        run: node gen_address_space
+        working-directory: tools/schema/
+      - name: Format generated code
+        # This invokes formatting of all nodeset children as well.
+        run: rustfmt lib/src/server/address_space/generated/mod.rs
+      - name: Verify generated code matches committed code
+        run: git status --porcelain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
   code-coverage:
     uses: ./.github/workflows/ci_code_coverage.yml
 
+  verify-clean-address-space:
+    uses: ./.github/workflows/ci_verify_clean_address_space.yml
+
   verify-clean-supported-message:
     uses: ./.github/workflows/ci_verify_clean_supported_message.yml
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 ignore = [
-    "server/src/address_space/generated",
     "types/src/node_ids.rs",
     "types/src/service_types",
 ]


### PR DESCRIPTION
> in order to enforce congruence between it and the source nodeset.
> 
> Furthermore drop the generated file from rustfmt ignore
> as it's apparently currently formatted.