### PR TITLE
ci: Regenerate and verify the types files

### DIFF
--- a/.github/workflows/ci_verify_clean_types.yml
+++ b/.github/workflows/ci_verify_clean_types.yml
@@ -1,0 +1,19 @@
+name: CI verify cleanly generated types
+'on':
+  workflow_call: null
+jobs:
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+        working-directory: tools/schema/
+      - name: Regenerate types
+        run: node gen_types
+        working-directory: tools/schema/
+      - name: Format generated code
+        run: rustfmt lib/src/types/service_types/mod.rs
+      - name: Verify generated code matches committed code
+        run: git status --porcelain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
   verify-clean-supported-message:
     uses: ./.github/workflows/ci_verify_clean_supported_message.yml
 
+  verify-clean-types:
+    uses: ./.github/workflows/ci_verify_clean_types.yml
+
   verify-code-formatting:
     uses: ./.github/workflows/ci_format_code.yml
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
 ignore = [
     "types/src/node_ids.rs",
-    "types/src/service_types",
 ]

--- a/tools/schema/types.js
+++ b/tools/schema/types.js
@@ -59,6 +59,9 @@ function makeImportLookupMap(import_map) {
     return result;
 }
 
+// Types that will be marked as Default constructable
+const DEFAULT_TYPES = ["ReadValueId", ];
+
 // Types that will be marked as JSON serializable. Serialization is for pubsub, and debugging purposes
 const JSON_SERIALIZED_TYPES = [
     "ReadValueId", "DataChangeFilter", "EventFilter", "SimpleAttributeOperand", "ContentFilter",
@@ -623,11 +626,15 @@ use std::io::{Read, Write};
         contents += `/// ${structured_type.documentation}\n`;
     }
 
+    const is_default_constructable = _.includes(DEFAULT_TYPES, structured_type.name);
     const is_json_serializable = _.includes(JSON_SERIALIZED_TYPES, structured_type.name);
 
     let derivations = "Debug, Clone, PartialEq";
     if (is_json_serializable) {
         derivations += ", Serialize, Deserialize";
+    }
+    if (is_default_constructable) {
+        derivations += ", Default";
     }
     contents += `#[derive(${derivations})]
 `;


### PR DESCRIPTION
> in order to enforce congruence between them and the schema.
> 
> Furthermore drop the generated files from rustfmt ignore
> as they're apparently currently formatted.

Also this resolves #349.