### PR TITLE
ci: Regenerate and verify the node ids file

### DIFF
--- a/.github/workflows/ci_verify_clean_node_ids.yml
+++ b/.github/workflows/ci_verify_clean_node_ids.yml
@@ -1,0 +1,19 @@
+name: CI verify cleanly generated node ids
+'on':
+  workflow_call: null
+jobs:
+  node_ids:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+        working-directory: tools/schema/
+      - name: Regenerate node ids
+        run: node gen_node_ids
+        working-directory: tools/schema/
+      - name: Format generated code
+        run: rustfmt lib/src/types/node_ids.rs
+      - name: Verify generated code matches committed code
+        run: git status --porcelain

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,9 @@ jobs:
   verify-clean-address-space:
     uses: ./.github/workflows/ci_verify_clean_address_space.yml
 
+  verify-clean-node-ids:
+    uses: ./.github/workflows/ci_verify_clean_node_ids.yml
+
   verify-clean-supported-message:
     uses: ./.github/workflows/ci_verify_clean_supported_message.yml
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-ignore = [
-    "types/src/node_ids.rs",
-]


### PR DESCRIPTION
> in order to enforce congruence between it and the source file.
> 
> Furthermore drop the generated file from rustfmt ignore as it's apparently currently formatted.