### PR TITLE
fix: Avert breakage with rust 1.80.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,16 @@ env:
 
 jobs:
   build-linux:
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Provision toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --features test-vendored-openssl
       - name: Run tests
@@ -24,11 +31,18 @@ jobs:
           sh ./run.sh
 
   build-windows:
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
     runs-on: windows-latest
     env:
       VCPKGRS_DYNAMIC: 1
     steps:
       - uses: actions/checkout@v3
+      - name: Provision toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --features test-vendored-openssl
       - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
  "serde_urlencoded 0.7.1",
  "smallvec 1.13.2",
  "socket2 0.5.6",
- "time 0.3.34",
+ "time 0.3.36",
  "url 2.5.0",
 ]
 
@@ -708,7 +708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding 2.3.1",
- "time 0.3.34",
+ "time 0.3.36",
  "version_check 0.9.4",
 ]
 
@@ -1905,6 +1905,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempdir",
+ "time 0.3.36",
  "tokio 1.36.0",
  "tokio-util",
  "url 1.7.2",
@@ -3027,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa 1.0.11",
@@ -3048,9 +3049,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -74,6 +74,8 @@ actix-web = { version = "4.4", optional = true }
 actix-files = { version = "0.6", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 arc-swap = "1.6.0"
+# https://github.com/rust-lang/rust/issues/125319
+time = "0.3.36"
 
 [dev-dependencies]
 tempdir = "0.3"


### PR DESCRIPTION
> By setting time 0.3.36 as minimally required version in accordance to https://github.com/rust-lang/rust/issues/125319#issuecomment-2120809372

@vlnzrv I think this is the least invasive resolution to the ongoing crate breakage due to the regression in 1.80.0.

Starting in eight days the opcua crate won't build in an up to date rust/stable anymore.
