### PR TITLE
ci: Run builds across the beta channel as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,16 @@ env:
 
 jobs:
   build-linux:
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Provision toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --features test-vendored-openssl
       - name: Run tests
@@ -24,11 +31,18 @@ jobs:
           sh ./run.sh
 
   build-windows:
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
     runs-on: windows-latest
     env:
       VCPKGRS_DYNAMIC: 1
     steps:
       - uses: actions/checkout@v4
+      - name: Provision toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - name: Build
         run: cargo build --features test-vendored-openssl
       - name: Run tests


### PR DESCRIPTION
> as this might help detecting upcoming rust issues earlier next time.
> 
> (cherry picked from commit 1c0bc5cbd65dcd0dcca61e6d0000bbb9c3200cc5)

~This is just a verification of @vlnzrv's finding which gets resolved in #361.~
~This is not meant to be merged by its own.~

Now that #361 has been superseeded by a52f8f739f5c, the CI addition is the only interesting thing left in this PR: