### PR TITLE
ci: Use codecov token to upload master branch measurements

### DIFF
--- a/.github/workflows/ci_code_coverage.yml
+++ b/.github/workflows/ci_code_coverage.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Upload lcov to codecov.io
         uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: target/coverage/*.lcov
 


### PR DESCRIPTION
Alright, this should allow for coverage report of main to be published to codecov.

@locka99 There should be a token for you to take from this codecov-page:

https://app.codecov.io/github/locka99/opcua/settings

to register as repo-secret as described on this page:

https://docs.codecov.com/docs/adding-the-codecov-token#github-actions

Once that is done and this PR merged, codecov should work as expected.