### PR TITLE
refactor: Drop imports of components only used once

### DIFF
--- a/samples/demo-server/src/machine.rs
+++ b/samples/demo-server/src/machine.rs
@@ -7,10 +7,7 @@ use std::sync::{
     Arc,
 };
 
-use chrono;
 use chrono::TimeDelta;
-use rand;
-
 use opcua::server::{events::event::*, prelude::*};
 
 pub fn add_machinery(server: &mut Server, ns: u16, raise_event: bool) {

--- a/samples/demo-server/src/main.rs
+++ b/samples/demo-server/src/main.rs
@@ -22,8 +22,6 @@ extern crate log;
 
 use std::{path::PathBuf, sync::Arc};
 
-use tokio;
-
 use opcua::server::{http, prelude::*};
 use opcua::sync::RwLock;
 


### PR DESCRIPTION
> such as `use somecrate` is unnecessary in rust.