### PR TITLE
Fixes to symmetric decryption

### DIFF
--- a/lib/src/client/session/services/session.rs
+++ b/lib/src/client/session/services/session.rs
@@ -67,18 +67,6 @@ impl Session {
         if let SupportedMessage::CreateSessionResponse(response) = response {
             process_service_result(&response.response_header)?;
 
-            let session_id = {
-                self.session_id.store(Arc::new(response.session_id.clone()));
-                response.session_id.clone()
-            };
-            self.auth_token
-                .store(Arc::new(response.authentication_token));
-
-            self.channel.update_from_created_session(
-                &response.server_nonce,
-                &response.server_certificate,
-            )?;
-
             let security_policy = self.channel.security_policy();
 
             if security_policy != SecurityPolicy::None {
@@ -106,6 +94,18 @@ impl Session {
                     return Err(StatusCode::BadCertificateInvalid);
                 }
             }
+
+            let session_id = {
+                self.session_id.store(Arc::new(response.session_id.clone()));
+                response.session_id.clone()
+            };
+            self.auth_token
+                .store(Arc::new(response.authentication_token));
+
+            self.channel.update_from_created_session(
+                &response.server_nonce,
+                &response.server_certificate,
+            )?;
 
             Ok(session_id)
         } else {

--- a/lib/src/client/transport/core.rs
+++ b/lib/src/client/transport/core.rs
@@ -181,10 +181,11 @@ impl TransportState {
 
         match chunk_info.message_header.is_final {
             MessageIsFinalType::Intermediate => {
-                debug!(
-                    "receive chunk intermediate {}:{}",
+                trace!(
+                    "receive chunk intermediate {}:{}. Length {}",
                     chunk_info.sequence_header.request_id,
-                    chunk_info.sequence_header.sequence_number
+                    chunk_info.sequence_header.sequence_number,
+                    chunk_info.body_length
                 );
                 message_state.chunks.push(MessageChunkWithChunkInfo {
                     header: chunk_info,
@@ -210,6 +211,12 @@ impl TransportState {
                     .send(Err(StatusCode::BadCommunicationError));
             }
             MessageIsFinalType::Final => {
+                trace!(
+                    "receive chunk final {}:{}. Length {}",
+                    chunk_info.sequence_header.request_id,
+                    chunk_info.sequence_header.sequence_number,
+                    chunk_info.body_length
+                );
                 message_state.chunks.push(MessageChunkWithChunkInfo {
                     header: chunk_info,
                     data_with_header: chunk.data,

--- a/lib/src/core/comms/tcp_types.rs
+++ b/lib/src/core/comms/tcp_types.rs
@@ -25,7 +25,7 @@ pub const CHUNK_INTERMEDIATE: u8 = b'C';
 pub const CHUNK_FINAL_ERROR: u8 = b'A';
 
 /// Minimum size in bytes than any single message chunk can be
-pub const MIN_CHUNK_SIZE: usize = 8196;
+pub const MIN_CHUNK_SIZE: usize = 8192;
 
 /// Size in bytes of an OPC UA message header
 pub const MESSAGE_HEADER_LEN: usize = 8;

--- a/lib/src/core/tests/chunk.rs
+++ b/lib/src/core/tests/chunk.rs
@@ -466,7 +466,8 @@ fn security_policy_symmetric_encrypt_decrypt() {
     let decrypted_len = secure_channel2
         .symmetric_decrypt_and_verify(&dst, 0..80, 20..100, &mut src2)
         .unwrap();
-    assert_eq!(decrypted_len, 100);
+    // End is at 100 - signature (20) - 1
+    assert_eq!(decrypted_len, 79);
 
     // Compare the data, not the signature
     assert_eq!(&src[..80], &src2[..80]);

--- a/lib/src/core/tests/hello.rs
+++ b/lib/src/core/tests/hello.rs
@@ -69,12 +69,12 @@ fn valid_buffer_sizes() {
         endpoint_url: UAString::null(),
     };
     assert!(!h.is_valid_buffer_sizes());
-    h.receive_buffer_size = 8195;
+    h.receive_buffer_size = 8191;
     assert!(!h.is_valid_buffer_sizes());
-    h.send_buffer_size = 8195;
+    h.send_buffer_size = 8191;
     assert!(!h.is_valid_buffer_sizes());
-    h.receive_buffer_size = 8196;
+    h.receive_buffer_size = 8192;
     assert!(!h.is_valid_buffer_sizes());
-    h.send_buffer_size = 8196;
+    h.send_buffer_size = 8192;
     assert!(h.is_valid_buffer_sizes());
 }


### PR DESCRIPTION
Remove padding when decrypting symmetric messages.

Also fixes a pair of minor issues:

 - We stored the session ID before actually validating that we got a valid session. This stuff can still be improved, but this at least fixes an obvious hole.
 - 2^13 is 8192, not 8196, this is also what the standard uses.

Should fix #373 