### PR TITLE
Refactored client's symmetric_decrypt_and_verify()

### DIFF
--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -1217,7 +1217,6 @@ impl SecureChannel {
                     &mut decrypted_tmp[..],
                 )?;
 
-                // Self::log_crypto_data("Encrypted buffer", &src[..encrypted_range.end]);
                 let encrypted_range =
                     encrypted_range.start..(encrypted_range.start + decrypted_size);
                 dst[encrypted_range.clone()].copy_from_slice(&decrypted_tmp[..decrypted_size]);

--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -1195,11 +1195,12 @@ impl SecureChannel {
                     signed_range,
                     signed_range.end
                 );
+                let signature_range = signed_range.end..;
                 let verification_key = self.verification_key();
                 self.security_policy.symmetric_verify_signature(
                     verification_key,
-                    &dst[signed_range.clone()],
-                    &dst[signed_range.end..],
+                    &dst[signed_range],
+                    &dst[signature_range],
                 )?;
 
                 Ok(encrypted_range.end)

--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -1198,10 +1198,6 @@ impl SecureChannel {
 
                 // There is an expectation that the block is padded so, this is a quick test
                 let ciphertext_size = encrypted_range.end - encrypted_range.start;
-                //                if ciphertext_size % 16 != 0 {
-                //                    error!("The cipher text size is not padded properly, size = {}", ciphertext_size);
-                //                    return Err(StatusCode::BadUnexpectedError);
-                //                }
 
                 // Copy security header
                 dst[..encrypted_range.start].copy_from_slice(&src[..encrypted_range.start]);

--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -1187,10 +1187,8 @@ impl SecureChannel {
             }
             MessageSecurityMode::Sign => {
                 self.expect_supported_security_policy();
-                // Copy everything
-                let all = ..src.len();
-                trace!("copying from slice {:?}", all);
-                dst[all].copy_from_slice(&src[all]);
+                trace!("copying from slice {:?}", ..src.len());
+                dst.copy_from_slice(src);
                 // Verify signature
                 trace!(
                     "Verifying range from {:?} to signature {}..",

--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -1182,8 +1182,7 @@ impl SecureChannel {
     ) -> Result<usize, StatusCode> {
         match self.security_mode {
             MessageSecurityMode::None => {
-                // Just copy everything from src to dst
-                dst[..].copy_from_slice(src);
+                dst.copy_from_slice(src);
                 Ok(src.len())
             }
             MessageSecurityMode::Sign => {

--- a/lib/src/core/comms/secure_channel.rs
+++ b/lib/src/core/comms/secure_channel.rs
@@ -1190,12 +1190,15 @@ impl SecureChannel {
                 trace!("copying from slice {:?}", ..src.len());
                 dst.copy_from_slice(src);
                 // Verify signature
-                trace!(
-                    "Verifying range from {:?} to signature {}..",
-                    signed_range,
-                    signed_range.end
-                );
+
                 let signature_range = signed_range.end..;
+
+                trace!(
+                    "Verifying signed range = {:?}, signature range = {:?}",
+                    signed_range,
+                    signature_range
+                );
+
                 let verification_key = self.verification_key();
                 self.security_policy.symmetric_verify_signature(
                     verification_key,
@@ -1243,17 +1246,20 @@ impl SecureChannel {
                 let signature_range = (encrypted_range.end
                     - self.security_policy.symmetric_signature_size())
                     ..encrypted_range.end;
+
                 trace!(
-                    "signed range = {:?}, signature range = {:?}",
+                    "Verifying signed range = {:?}, signature range = {:?}",
                     signed_range,
                     signature_range
                 );
+
                 let verification_key = self.verification_key();
                 self.security_policy.symmetric_verify_signature(
                     verification_key,
                     &dst[signed_range],
                     &dst[signature_range],
                 )?;
+
                 Ok(encrypted_range.end)
             }
             MessageSecurityMode::Invalid => {


### PR DESCRIPTION
Hello, I'm trying to fix the issue that is mentioned in #207 and would like to clean up symmetric_decrypt_and_verify() first.

Here is a list of small changes that I made:
1. Removed commented out old code
2. Simplified indexing of slices (using slice directly instead of dst[..], removed "all" variable")
3. Unified trace message + signature verifying in 2 match arms (Sign, SignAndEncrypt) into a new method

Please let me know if any of the removed code is still needed or I missed something during the refactoring.

Thanks!

