### PR TITLE
Use dynamic publish requests limits based on subscriptions and latency

### DIFF
--- a/lib/src/client/builder.rs
+++ b/lib/src/client/builder.rs
@@ -246,12 +246,6 @@ impl ClientBuilder {
         self
     }
 
-    /// Maximum number of pending publish requests.
-    pub fn max_inflight_publish(mut self, max_inflight_publish: usize) -> Self {
-        self.config.max_inflight_publish = max_inflight_publish;
-        self
-    }
-
     /// Sets the session timeout period, in milliseconds.
     pub fn session_timeout(mut self, session_timeout: u32) -> Self {
         self.config.session_timeout = session_timeout;
@@ -270,12 +264,6 @@ impl ClientBuilder {
     /// This is the maximum number of monitored items to create per request.
     pub fn recreate_monitored_items_chunk(mut self, recreate_monitored_items_chunk: usize) -> Self {
         self.config.performance.recreate_monitored_items_chunk = recreate_monitored_items_chunk;
-        self
-    }
-
-    /// Maximum number of inflight messages.
-    pub fn max_inflight_messages(mut self, max_inflight_messages: usize) -> Self {
-        self.config.performance.max_inflight_messages = max_inflight_messages;
         self
     }
 

--- a/lib/src/client/config.rs
+++ b/lib/src/client/config.rs
@@ -161,8 +161,6 @@ pub struct Performance {
     pub(crate) ignore_clock_skew: bool,
     /// Maximum number of monitored items per request when recreating subscriptions on session recreation.
     pub(crate) recreate_monitored_items_chunk: usize,
-    /// Maximum number of inflight messages.
-    pub(crate) max_inflight_messages: usize,
 }
 
 /// Client OPC UA configuration
@@ -218,8 +216,6 @@ pub struct ClientConfig {
     /// Minimum publish interval. Setting this higher will make sure that subscriptions
     /// publish together, which may reduce the number of publish requests if you have a lot of subscriptions.
     pub(crate) min_publish_interval: Duration,
-    /// Maximum number of inflight publish requests before further requests are skipped.
-    pub(crate) max_inflight_publish: usize,
 
     /// Requested session timeout in milliseconds
     pub(crate) session_timeout: u32,
@@ -358,7 +354,6 @@ impl ClientConfig {
             request_timeout: Duration::from_secs(60),
             min_publish_interval: Duration::from_secs(1),
             publish_timeout: Duration::from_secs(60),
-            max_inflight_publish: 2,
             session_timeout: 0,
             decoding_options: DecodingOptions {
                 max_array_length: decoding_options.max_array_length,
@@ -372,7 +367,6 @@ impl ClientConfig {
             performance: Performance {
                 ignore_clock_skew: false,
                 recreate_monitored_items_chunk: 1000,
-                max_inflight_messages: 20,
             },
             session_name: "Rust OPC UA Client".into(),
         }

--- a/lib/src/client/session/client.rs
+++ b/lib/src/client/session/client.rs
@@ -364,7 +364,6 @@ impl Client {
             Arc::default(),
             TransportConfiguration {
                 max_pending_incoming: 5,
-                max_inflight: self.config.performance.max_inflight_messages,
                 send_buffer_size: self.config.decoding_options.max_chunk_size,
                 recv_buffer_size: self.config.decoding_options.max_incoming_chunk_size,
                 max_message_size: self.config.decoding_options.max_message_size,

--- a/lib/src/client/session/event_loop.rs
+++ b/lib/src/client/session/event_loop.rs
@@ -280,6 +280,7 @@ impl SessionActivityLoop {
         futures::stream::unfold(self, |mut slf| async move {
             match slf.tick_gen.next().await {
                 SessionTickEvent::KeepAlive => {
+                    let now = Instant::now();
                     let res = slf
                         .inner
                         .read(
@@ -293,11 +294,19 @@ impl SessionActivityLoop {
                             1f64,
                         )
                         .await;
+                    let elapsed = now.elapsed();
 
-                    let value = match res.map(|r| r.into_iter().next()) {
-                        Ok(Some(dv)) => dv,
-                        // Should not be possible, this would be a bug in the server, assume everything
-                        // is terrible.
+                    let data_value = match res.map(|r| r.into_iter().next()) {
+                        Ok(Some(data_value)) => {
+                            // Only update if the request was successful to avoid
+                            // skewing the roundtrip time by processing timeouts.
+                            slf.inner
+                                .publish_limits_watch_tx
+                                .send_modify(|limits| limits.update_message_roundtrip(elapsed));
+                            data_value
+                        }
+                        // Should not be possible, this would be a bug in
+                        // the server, assume everything is terrible.
                         Ok(None) => {
                             return Some((
                                 SessionActivity::KeepAliveFailed(StatusCode::BadUnknownResponse),
@@ -307,24 +316,19 @@ impl SessionActivityLoop {
                         Err(e) => return Some((SessionActivity::KeepAliveFailed(e), slf)),
                     };
 
-                    let Some(status): Option<u8> = value.value.and_then(|v| v.try_into().ok())
-                    else {
-                        return Some((
-                            SessionActivity::KeepAliveFailed(StatusCode::BadUnknownResponse),
-                            slf,
-                        ));
-                    };
-
-                    match status {
-                        // ServerState::Running
-                        0 => Some((SessionActivity::KeepAliveSucceeded, slf)),
-                        s => {
+                    match data_value.value.and_then(|v| v.try_into().ok()) {
+                        Some(0) => Some((SessionActivity::KeepAliveSucceeded, slf)),
+                        Some(s) => {
                             warn!("Keep alive failed, non-running status code {s}");
                             Some((
                                 SessionActivity::KeepAliveFailed(StatusCode::BadServerHalted),
                                 slf,
                             ))
                         }
+                        None => Some((
+                            SessionActivity::KeepAliveFailed(StatusCode::BadUnknownResponse),
+                            slf,
+                        )),
                     }
                 }
             }

--- a/lib/src/client/session/services/subscriptions/event_loop.rs
+++ b/lib/src/client/session/services/subscriptions/event_loop.rs
@@ -27,9 +27,8 @@ pub enum SubscriptionActivity {
 pub struct SubscriptionEventLoop {
     session: Arc<Session>,
     trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
-    max_inflight_publish: usize,
     last_external_trigger: Instant,
-    // This is true if the client has received a message BadTooManyPublishRequests
+    // This is true if the client has received BadTooManyPublishRequests
     // and is waiting for a response before making further requests.
     is_waiting_for_response: bool,
 }
@@ -41,15 +40,14 @@ impl SubscriptionEventLoop {
     ///
     ///  * `session` - A shared reference to an [AsyncSession].
     ///  * `trigger_publish_recv` - A channel used to transmit external publish triggers.
-    ///  This is used to trigger publish outside of the normal schedule, for example when
-    ///  a new subscription is created.
+    ///    This is used to trigger publish outside of the normal schedule, for example when
+    ///    a new subscription is created.
     pub fn new(
         session: Arc<Session>,
         trigger_publish_recv: tokio::sync::watch::Receiver<Instant>,
     ) -> Self {
-        let last_external_trigger = trigger_publish_recv.borrow().clone();
+        let last_external_trigger = *trigger_publish_recv.borrow();
         Self {
-            max_inflight_publish: session.max_inflight_publish,
             last_external_trigger,
             trigger_publish_recv,
             session,
@@ -69,9 +67,9 @@ impl SubscriptionEventLoop {
                     slf.trigger_publish_recv.clone();
 
                 let res = loop {
-                    // Future for the next periodic publish. We do not send publish requests if there
-                    // are no active subscriptions. In this case, simply return the non-terminating
-                    // future.
+                    // Future for the next periodic publish. We do not send publish requests
+                    // if there are no active subscriptions. In this case, simply return the
+                    // non-terminating future.
                     let next_tick_fut = if let Some(next) = next {
                         if slf.is_waiting_for_response && !futures.is_empty() {
                             Either::Right(futures::future::pending::<()>())
@@ -81,8 +79,9 @@ impl SubscriptionEventLoop {
                     } else {
                         Either::Right(futures::future::pending::<()>())
                     };
-                    // If FuturesUnordered is empty, it will immediately yield `None`. We don't want that,
-                    // so if it is empty we return the non-terminating future.
+
+                    // If FuturesUnordered is empty, it will immediately yield `None`. We don't
+                    // want that, so if it is empty we return the non-terminating future.
                     let next_publish_fut = if futures.is_empty() {
                         Either::Left(futures::future::pending())
                     } else {
@@ -93,65 +92,98 @@ impl SubscriptionEventLoop {
                         // Both internal ticks and external triggers result in publish requests.
                         v = recv.wait_for(|i| i > &slf.last_external_trigger) => {
                             if let Ok(v) = v {
-                                debug!("Sending publish due to external trigger");
-                                // On an external trigger, we always publish.
-                                futures.push(slf.static_publish());
-                                next = slf.session.next_publish_time(true);
-                                slf.last_external_trigger = v.clone();
+                                if !slf.is_waiting_for_response {
+                                    debug!("Sending publish due to external trigger");
+                                    // On an external trigger, we always publish.
+                                    futures.push(slf.static_publish());
+                                    next = slf.session.next_publish_time(true);
+                                    slf.last_external_trigger = *v;
+                                } else {
+                                    debug!("Skipping publish due BadTooManyPublishRequests");
+                                }
                             }
                         }
                         _ = next_tick_fut => {
                             // Avoid publishing if there are too many inflight publish requests.
-                            if futures.len() < slf.max_inflight_publish {
-                                debug!("Sending publish due to internal tick");
-                                futures.push(slf.static_publish());
+                            if futures.len()
+                                < slf
+                                    .session
+                                    .publish_limits_watch_rx
+                                    .borrow()
+                                    .max_publish_requests
+                            {
+                                if !slf.is_waiting_for_response {
+                                    debug!("Sending publish due to internal tick");
+                                    futures.push(slf.static_publish());
+                                } else {
+                                    debug!("Skipping publish due BadTooManyPublishRequests");
+                                }
                             }
                             next = slf.session.next_publish_time(true);
                         }
                         res = next_publish_fut => {
                             match res {
-                                Some(Ok(should_publish_now)) => {
-                                    if should_publish_now {
-                                        futures.push(slf.static_publish());
-                                        // Set the last publish time.
-                                        // We do this to avoid a buildup of publish requests
-                                        // if exhausting the queue takes more time than
-                                        // a single publishing interval.
-                                        slf.session.next_publish_time(true);
+                                Some(Ok(more_notifications)) => {
+                                    if more_notifications
+                                        || futures.len()
+                                            < slf
+                                                .session
+                                                .publish_limits_watch_rx
+                                                .borrow()
+                                                .min_publish_requests
+                                    {
+                                        if !slf.is_waiting_for_response {
+                                            debug!("Sending publish after receiving response");
+                                            futures.push(slf.static_publish());
+                                            // Set the last publish time to to avoid a buildup
+                                            // of publish requests if exhausting the queue takes
+                                            // more time than a single publishing interval.
+                                            slf.session.next_publish_time(true);
+                                        } else {
+                                            debug!("Skipping publish due BadTooManyPublishRequests");
+                                        }
                                     }
                                     slf.is_waiting_for_response = false;
-
                                     break SubscriptionActivity::Publish
                                 }
                                 Some(Err(e)) => {
                                     match e {
                                         StatusCode::BadTimeout => {
-                                            session_debug!(slf.session, "Publish request timed out, sending another");
-                                            if futures.len() < slf.max_inflight_publish {
-                                                futures.push(slf.static_publish());
-                                            }
+                                            session_debug!(slf.session, "Publish request timed out");
                                         }
                                         StatusCode::BadTooManyPublishRequests => {
-                                            session_debug!(slf.session, "Server returned BadTooManyPublishRequests, backing off");
+                                            session_debug!(
+                                                slf.session,
+                                                "Server returned BadTooManyPublishRequests, backing off",
+                                            );
                                             slf.is_waiting_for_response = true;
                                         }
                                         StatusCode::BadSessionClosed
                                         | StatusCode::BadSessionIdInvalid => {
                                             // TODO: Do something here?
-                                            session_error!(slf.session, "Publish response indicates session is dead");
+                                            session_error!(
+                                                slf.session,
+                                                "Publish response indicates session is dead"
+                                            );
                                         }
                                         StatusCode::BadNoSubscription
                                         | StatusCode::BadSubscriptionIdInvalid => {
-                                            // TODO: Maybe do something here? This could happen when subscriptions are
-                                            // in the process of being recreated. Make sure to avoid race conditions.
-                                            session_error!(slf.session, "Publish response indicates subscription is dead");
+                                            // TODO: Maybe do something here? This could happen when
+                                            // subscriptions are in the process of being recreated.
+                                            // Make sure to avoid race conditions.
+                                            session_error!(
+                                                slf.session,
+                                                "Publish response indicates subscription is dead",
+                                            );
                                         }
                                         _ => ()
                                     }
                                     break SubscriptionActivity::PublishFailed(e)
                                 }
-                                // Should be impossible
-                                None => break SubscriptionActivity::PublishFailed(StatusCode::BadInvalidState)
+                                // Should be impossible.
+                                None => break SubscriptionActivity::PublishFailed(
+                                    StatusCode::BadInvalidState,
+                                )
                             }
                         }
                     }

--- a/lib/src/client/session/services/subscriptions/mod.rs
+++ b/lib/src/client/session/services/subscriptions/mod.rs
@@ -449,3 +449,46 @@ impl Subscription {
         }
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct PublishLimits {
+    message_roundtrip: Duration,
+    publish_interval: Duration,
+    subscriptions: usize,
+    min_publish_requests: usize,
+    max_publish_requests: usize,
+}
+
+impl PublishLimits {
+    const MIN_MESSAGE_ROUNDTRIP: Duration = Duration::from_millis(10);
+    const REQUESTS_PER_SUBSCRIPTION: usize = 2;
+
+    pub fn new() -> Self {
+        Self {
+            message_roundtrip: Self::MIN_MESSAGE_ROUNDTRIP,
+            publish_interval: Duration::ZERO,
+            subscriptions: 0,
+            min_publish_requests: 0,
+            max_publish_requests: 0,
+        }
+    }
+
+    pub fn update_message_roundtrip(&mut self, message_roundtrip: Duration) {
+        self.message_roundtrip = message_roundtrip.max(Self::MIN_MESSAGE_ROUNDTRIP);
+        self.calculate_publish_limits();
+    }
+
+    pub fn update_subscriptions(&mut self, subscriptions: usize, publish_interval: Duration) {
+        self.subscriptions = subscriptions;
+        self.publish_interval = publish_interval;
+        self.calculate_publish_limits();
+    }
+
+    fn calculate_publish_limits(&mut self) {
+        self.min_publish_requests = self.subscriptions * Self::REQUESTS_PER_SUBSCRIPTION;
+        self.max_publish_requests = (self.message_roundtrip.as_millis() as f32
+            / self.publish_interval.as_millis() as f32)
+            .ceil() as usize
+            * (self.min_publish_requests);
+    }
+}

--- a/lib/src/client/session/services/subscriptions/state.rs
+++ b/lib/src/client/session/services/subscriptions/state.rs
@@ -7,15 +7,16 @@ use crate::types::{
     DecodingOptions, MonitoringMode, NotificationMessage, SubscriptionAcknowledgement,
 };
 
-use super::{CreateMonitoredItem, ModifyMonitoredItem, Subscription};
+use super::{CreateMonitoredItem, ModifyMonitoredItem, PublishLimits, Subscription};
 
 /// State containing all known subscriptions in the session.
 pub struct SubscriptionState {
-    subscriptions: HashMap<u32, Subscription>,
-    last_publish: Instant,
     acknowledgements: Vec<SubscriptionAcknowledgement>,
     keep_alive_timeout: Option<Duration>,
+    last_publish: Instant,
     min_publish_interval: Duration,
+    publish_limits_watch_tx: tokio::sync::watch::Sender<PublishLimits>,
+    subscriptions: HashMap<u32, Subscription>,
 }
 
 impl SubscriptionState {
@@ -25,13 +26,17 @@ impl SubscriptionState {
     ///
     /// * `min_publishing_interval` - The minimum accepted publishing interval, any lower values
     /// will be set to this.
-    pub(crate) fn new(min_publish_interval: Duration) -> Self {
+    pub(crate) fn new(
+        min_publish_interval: Duration,
+        publish_limits_watch_tx: tokio::sync::watch::Sender<PublishLimits>,
+    ) -> Self {
         Self {
-            subscriptions: HashMap::new(),
-            last_publish: Instant::now() - min_publish_interval,
             acknowledgements: Vec::new(),
             keep_alive_timeout: None,
+            last_publish: Instant::now() - min_publish_interval,
             min_publish_interval,
+            publish_limits_watch_tx,
+            subscriptions: HashMap::new(),
         }
     }
 
@@ -94,6 +99,7 @@ impl SubscriptionState {
         self.subscriptions
             .insert(subscription.subscription_id(), subscription);
         self.set_keep_alive_timeout();
+        self.update_publish_limits();
     }
 
     pub(crate) fn modify_subscription(
@@ -118,6 +124,7 @@ impl SubscriptionState {
     pub(crate) fn delete_subscription(&mut self, subscription_id: u32) -> Option<Subscription> {
         let subscription = self.subscriptions.remove(&subscription_id);
         self.set_keep_alive_timeout();
+        self.update_publish_limits();
         subscription
     }
 
@@ -204,5 +211,19 @@ impl SubscriptionState {
             .values()
             .map(|v| v.publishing_interval() * v.lifetime_count())
             .min()
+    }
+
+    fn update_publish_limits(&mut self) {
+        let publish_interval = self
+            .subscriptions
+            .values()
+            .filter(|s| s.publishing_enabled())
+            .map(|s| s.publishing_interval().max(self.min_publish_interval))
+            .min()
+            .unwrap_or(Duration::ZERO);
+
+        self.publish_limits_watch_tx.send_modify(|limits| {
+            limits.update_subscriptions(self.subscriptions.len(), publish_interval);
+        });
     }
 }

--- a/lib/src/client/session/session.rs
+++ b/lib/src/client/session/session.rs
@@ -19,7 +19,10 @@ use crate::{
     types::{ApplicationDescription, DecodingOptions, NodeId, RequestHeader, StatusCode, UAString},
 };
 
-use super::{services::subscriptions::state::SubscriptionState, SessionEventLoop, SessionInfo};
+use super::{
+    services::subscriptions::{state::SubscriptionState, PublishLimits},
+    SessionEventLoop, SessionInfo,
+};
 
 #[derive(Clone, Copy)]
 pub enum SessionState {
@@ -53,8 +56,9 @@ pub struct Session {
     pub(super) publish_timeout: Duration,
     pub(super) recreate_monitored_items_chunk: usize,
     pub(super) session_timeout: f64,
-    pub(super) max_inflight_publish: usize,
     pub subscription_state: Mutex<SubscriptionState>,
+    pub(super) publish_limits_watch_rx: tokio::sync::watch::Receiver<PublishLimits>,
+    pub(super) publish_limits_watch_tx: tokio::sync::watch::Sender<PublishLimits>,
     pub(super) monitored_item_handle: AtomicHandle,
     pub(super) trigger_publish_tx: tokio::sync::watch::Sender<Instant>,
 }
@@ -69,7 +73,9 @@ impl Session {
         decoding_options: DecodingOptions,
         config: &ClientConfig,
     ) -> (Arc<Self>, SessionEventLoop) {
-        let auth_token: Arc<ArcSwap<NodeId>> = Default::default();
+        let auth_token: Arc<ArcSwap<NodeId>> = Arc::default();
+        let (publish_limits_watch_tx, publish_limits_watch_rx) =
+            tokio::sync::watch::channel(PublishLimits::new());
         let (state_watch_tx, state_watch_rx) =
             tokio::sync::watch::channel(SessionState::Disconnected);
         let (trigger_publish_tx, trigger_publish_rx) = tokio::sync::watch::channel(Instant::now());
@@ -84,7 +90,6 @@ impl Session {
                 auth_token.clone(),
                 TransportConfiguration {
                     max_pending_incoming: 5,
-                    max_inflight: config.performance.max_inflight_messages,
                     send_buffer_size: config.decoding_options.max_chunk_size,
                     recv_buffer_size: config.decoding_options.max_incoming_chunk_size,
                     max_message_size: config.decoding_options.max_message_size,
@@ -94,7 +99,7 @@ impl Session {
             internal_session_id: AtomicU32::new(NEXT_SESSION_ID.fetch_add(1, Ordering::Relaxed)),
             state_watch_rx,
             state_watch_tx,
-            session_id: Default::default(),
+            session_id: Arc::default(),
             session_info,
             auth_token,
             session_name,
@@ -103,10 +108,14 @@ impl Session {
             request_timeout: config.request_timeout,
             session_timeout: config.session_timeout as f64,
             publish_timeout: config.publish_timeout,
-            max_inflight_publish: config.max_inflight_publish,
             recreate_monitored_items_chunk: config.performance.recreate_monitored_items_chunk,
-            subscription_state: Mutex::new(SubscriptionState::new(config.min_publish_interval)),
+            subscription_state: Mutex::new(SubscriptionState::new(
+                config.min_publish_interval,
+                publish_limits_watch_tx.clone(),
+            )),
             monitored_item_handle: AtomicHandle::new(1000),
+            publish_limits_watch_rx,
+            publish_limits_watch_tx,
             trigger_publish_tx,
         });
 

--- a/lib/src/client/transport/channel.rs
+++ b/lib/src/client/transport/channel.rs
@@ -25,6 +25,11 @@ use crate::client::{
     },
 };
 
+// This is an arbitrary limit which should never be reached in practice,
+// it's just a safety net to prevent the client from consuming too much
+// memory if it gets into an unexpected (bad) state.
+const MAX_INFLIGHT_MESSAGES: usize = 1_000_000;
+
 /// Wrapper around an open secure channel
 pub struct AsyncSecureChannel {
     session_info: SessionInfo,
@@ -236,7 +241,7 @@ impl AsyncSecureChannel {
                 );
             }
 
-            let (send, recv) = tokio::sync::mpsc::channel(self.transport_config.max_inflight);
+            let (send, recv) = tokio::sync::mpsc::channel(MAX_INFLIGHT_MESSAGES);
             let transport = TcpTransport::connect(
                 self.secure_channel.clone(),
                 recv,

--- a/lib/src/client/transport/core.rs
+++ b/lib/src/client/transport/core.rs
@@ -32,8 +32,6 @@ pub(super) struct TransportState {
     outgoing_recv: tokio::sync::mpsc::Receiver<OutgoingMessage>,
     /// State of pending requests
     message_states: HashMap<u32, MessageState>,
-    /// Maximum number of inflight requests, or None if unlimited.
-    max_inflight: usize,
     /// Secure channel
     pub(super) secure_channel: Arc<RwLock<SecureChannel>>,
     /// Max pending incoming messages
@@ -61,13 +59,11 @@ impl TransportState {
         secure_channel: Arc<RwLock<SecureChannel>>,
         outgoing_recv: tokio::sync::mpsc::Receiver<OutgoingMessage>,
         max_pending_incoming: usize,
-        max_inflight: usize,
     ) -> Self {
         Self {
             secure_channel,
             outgoing_recv,
             message_states: HashMap::new(),
-            max_inflight,
             max_pending_incoming,
             last_received_sequence_number: 0,
         }
@@ -86,29 +82,24 @@ impl TransportState {
                 None => Either::Right(futures::future::pending::<()>()),
             };
 
-            // Only listen for outgoing messages if the number of inflight messages is below the limit.
-            if self.max_inflight > self.message_states.len() {
-                tokio::select! {
-                    _ = timeout_fut => {
-                        continue;
-                    }
-                    outgoing = self.outgoing_recv.recv() => {
-                        let Some(outgoing) = outgoing else {
-                            return None;
-                        };
-                        let request_id = send_buffer.next_request_id();
-                        if let Some(callback) = outgoing.callback {
-                            self.message_states.insert(request_id, MessageState {
-                                callback,
-                                chunks: Vec::new(),
-                                deadline: outgoing.deadline,
-                            });
-                        }
-                        break Some((outgoing.request, request_id));
-                    }
+            tokio::select! {
+                _ = timeout_fut => {
+                    continue;
                 }
-            } else {
-                timeout_fut.await;
+                outgoing = self.outgoing_recv.recv() => {
+                    let Some(outgoing) = outgoing else {
+                        return None;
+                    };
+                    let request_id = send_buffer.next_request_id();
+                    if let Some(callback) = outgoing.callback {
+                        self.message_states.insert(request_id, MessageState {
+                            callback,
+                            chunks: Vec::new(),
+                            deadline: outgoing.deadline,
+                        });
+                    }
+                    break Some((outgoing.request, request_id));
+                }
             }
         }
     }

--- a/lib/src/client/transport/tcp.rs
+++ b/lib/src/client/transport/tcp.rs
@@ -35,7 +35,6 @@ pub(crate) struct TcpTransport {
 #[derive(Debug, Clone)]
 pub struct TransportConfiguration {
     pub max_pending_incoming: usize,
-    pub max_inflight: usize,
     pub send_buffer_size: usize,
     pub recv_buffer_size: usize,
     pub max_message_size: usize,
@@ -59,12 +58,7 @@ impl TcpTransport {
             };
 
         Ok(Self {
-            state: TransportState::new(
-                secure_channel,
-                outgoing_recv,
-                config.max_pending_incoming,
-                config.max_inflight,
-            ),
+            state: TransportState::new(secure_channel, outgoing_recv, config.max_pending_incoming),
             read: framed_read,
             write: writer,
             send_buffer: SendBuffer::new(

--- a/samples/client.conf
+++ b/samples/client.conf
@@ -64,10 +64,8 @@ publish_timeout:
 min_publish_interval:
   secs: 1
   nanos: 0
-max_inflight_publish: 2
 session_timeout: 0
 performance:
   ignore_clock_skew: false
   recreate_monitored_items_chunk: 1000
-  max_inflight_messages: 20
 session_name: Rust OPC UA Client


### PR DESCRIPTION
This PR tries to incorporate both publishing strategies as described in the [spec](https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.5):

> Client strategies for issuing Publish requests may vary depending on the networking delays between the Client and the Server. In many cases, the Client may wish to issue a Publish request immediately after creating a Subscription, and thereafter, immediately after receiving a Publish response.
>
> In other cases, especially in high latency networks, the Client may wish to pipeline Publish requests to ensure cyclic reporting from the Server. Pipelining involves sending more than one Publish request for each Subscription before receiving a response. For example, if the network introduces a delay between the Client and the Server of 5 seconds and the publishing interval for a Subscription is one second, then the Client shall issue Publish requests every second instead of waiting for a response to be received before sending the next request.

It follows the first strategy by sending a publish request right after a subscription is created and immediately responding to a publish response with a new request if the number of inflight publish requests is less then the currently active subscriptions times two (so that there is always one available at the server while the client is processing the other one). So this (active subscriptions times two) defines the `min_publish_requests`.

In most low-latency environments this is enough to make sure the server always has a publish request available. Even if the server had a temporary performance issue (e.g. due to a backup or other external process) and wasn't able to send the publish response within the specified window, it is able to "catch up" due to the fact that the client will immediately send a new publish request instead of waiting for a certain interval to have passed.

But in case the network between your client and the sever has a high latency, this approach alone is not enough to make sure there are enough publish requests available to the server to be able to send continuous publish responses. So in addition to the above we also keep track of the current network latency by measuring how long the round-trip of the keep-alive messages take. We divide the measured round-trip time by the lowest publish interval of the active subscriptions and multiple that by the `min_publish_requests` to define the `max_publish_requests`.

Changes in the `max_publish_requests` will be handled by checking at every publish interval. When the timer ticks it will check if the total number of in flight requests in below the `max_publish_requests` and if so, send an additional publish request.

We checked this approach against different types of servers and with different types of networks (with fluctuating latency) and the combined strategy was able to adjust itself in all tested situations so that there always was a steady flow of publish requests and responses.