### PR TITLE
use runtime handle for `Server::run_server_on_runtime` and `http::run_http_server` instead of runtime

### DIFF
--- a/lib/src/server/http/mod.rs
+++ b/lib/src/server/http/mod.rs
@@ -6,7 +6,7 @@ use std::{path::PathBuf, sync::Arc, thread};
 
 use actix_files as fs;
 use actix_web::{web, App, HttpResponse, HttpServer, Responder, Result};
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 
 use crate::sync::*;
 
@@ -73,7 +73,7 @@ async fn metrics(data: web::Data<AppState>) -> impl Responder {
 
 /// Runs an http server on the specified binding address, serving out the supplied server metrics
 pub fn run_http_server(
-    runtime: &Runtime,
+    handle: &Handle,
     address: &str,
     content_path: &str,
     server_state: Arc<RwLock<ServerState>>,
@@ -87,7 +87,7 @@ pub fn run_http_server(
     // Getting this working was very painful since Actix HttpServer does not implement Send trait, so the
     // code has to run on a single thread, but also async and through Tokio.
 
-    let runtime_handle = runtime.handle().clone();
+    let runtime_handle = handle.clone();
     thread::spawn(move || {
         info!(
             "HTTP server is running on http://{}/ to provide OPC UA server metrics",

--- a/lib/src/server/server.rs
+++ b/lib/src/server/server.rs
@@ -240,7 +240,7 @@ impl Server {
             tokio::runtime::Builder::new_current_thread()
         };
         let runtime = builder.enable_all().build().unwrap();
-        Self::run_server_on_runtime(runtime, server_task, true);
+        Self::run_server_on_runtime(runtime.handle(), server_task, true);
     }
 
     /// Allow the server to be run on a caller supplied runtime. If block is set, the task
@@ -248,7 +248,7 @@ impl Server {
     /// returned by the function. Spawning might be suitable if the runtime is being used for other
     /// async tasks.
     pub fn run_server_on_runtime<F>(
-        runtime: tokio::runtime::Runtime,
+        handle: &tokio::runtime::Handle,
         server_task: F,
         block: bool,
     ) -> Option<tokio::task::JoinHandle<<F as futures::Future>::Output>>
@@ -257,11 +257,11 @@ impl Server {
         F::Output: Send + 'static,
     {
         if block {
-            runtime.block_on(server_task);
+            handle.block_on(server_task);
             info!("Server has finished");
             None
         } else {
-            Some(runtime.spawn(server_task))
+            Some(handle.spawn(server_task))
         }
     }
 

--- a/samples/demo-server/src/main.rs
+++ b/samples/demo-server/src/main.rs
@@ -146,25 +146,27 @@ fn main() {
             .build()
             .unwrap();
 
+        let handle = runtime.handle();
+
         // Start the http server, used for metrics
-        start_http_server(&runtime, &server, args.content_path.to_str().unwrap());
+        start_http_server(&handle, &server, args.content_path.to_str().unwrap());
 
         // Run the server. This does not ordinarily exit so you must Ctrl+C to terminate
         Server::run_server_on_runtime(
-            runtime,
+            handle,
             Server::new_server_task(Arc::new(RwLock::new(server))),
             true,
         );
     }
 }
 
-fn start_http_server(runtime: &tokio::runtime::Runtime, server: &Server, content_path: &str) {
+fn start_http_server(handle: &tokio::runtime::Handle, server: &Server, content_path: &str) {
     let server_state = server.server_state();
     let connections = server.connections();
     let metrics = server.server_metrics();
     // The index.html is in a path relative to the working dir.
     let _ = http::run_http_server(
-        runtime,
+        handle,
         "127.0.0.1:8585",
         content_path,
         server_state,


### PR DESCRIPTION
closes #415

Using a `tokio::runtime::Handle` prevents the runtime from being dropped in the function `run_server_on_runtime` when block is set to false. Currently the runtime aborts all tasks, since the runtime is dropped. Details see #415. Additionally it allows the use of `Handle::current()` instead of requiring the user to create the runtime explicitly.